### PR TITLE
Mandarine dependent modules are now located inside mandarine's project.

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { Application, Cookies, Request, Router, Context, Middleware, isHttpError, Status } from "https://deno.land/x/oak@v5.3.1/mod.ts";
+export { Application, Cookies, Request, Router, Context, Middleware, isHttpError, Status } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/oak/5.3.1/mod.ts";

--- a/mvc-framework/core/modules/view-engine/renderEngine.ts
+++ b/mvc-framework/core/modules/view-engine/renderEngine.ts
@@ -1,6 +1,6 @@
-import { renderDenjuck } from "https://deno.land/x/view_engine/lib/engines/denjuck.ts";
-import { renderEjs } from "https://deno.land/x/view_engine/lib/engines/ejs.ts";
-import { renderHandlebars } from "https://deno.land/x/view_engine/lib/engines/handlebars.ts";
+import { renderDenjuck } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/view-engine/1.1.1/lib/engines/denjuck.ts";
+import { renderEjs } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/view-engine/1.1.1/lib/engines/ejs.ts";
+import { renderHandlebars } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/view-engine/1.1.1/lib/engines/handlebars.ts";
 import { ApplicationContext } from "../../../../main-core/application-context/mandarineApplicationContext.ts";
 import { TemplateEngineException } from "../../../../main-core/exceptions/templateEngineException.ts";
 import { Mandarine } from "../../../../main-core/Mandarine.ns.ts";

--- a/orm-core/connectors/postgreSQLConnector.ts
+++ b/orm-core/connectors/postgreSQLConnector.ts
@@ -1,6 +1,6 @@
-import { PoolClient } from "https://deno.land/x/postgres/client.ts";
-import { Pool } from "https://deno.land/x/postgres/mod.ts";
-import { QueryConfig, QueryResult } from "https://deno.land/x/postgres/query.ts";
+import { PoolClient } from "https://raw.githubusercontent.com/mandarineorg/mandarine-postgres/master/client.ts";
+import { Pool } from "https://raw.githubusercontent.com/mandarineorg/mandarine-postgres/master/mod.ts";
+import { QueryConfig, QueryResult } from "https://raw.githubusercontent.com/mandarineorg/mandarine-postgres/master/query.ts";
 import { Log } from "../../logger/log.ts";
 import { Mandarine } from "../../main-core/Mandarine.ns.ts";
 import { MandarineORMException } from "../core/exceptions/mandarineORMException.ts";


### PR DESCRIPTION
Mandarine dependent modules are now located inside mandarine's project.
https://github.com/mandarineorg/mandarinets-modules

Close #53 