### PR TITLE
mandarine.json is now supported.

### DIFF
--- a/main-core/components-registry/componentRegistry.ts
+++ b/main-core/components-registry/componentRegistry.ts
@@ -160,15 +160,17 @@ export class ComponentsRegistry implements Mandarine.MandarineCore.IComponentsRe
         repositoryMethods = repositoryMethods.concat(mandarineRepositoryMethods);
         
         let repositoryProxy: Mandarine.ORM.RepositoryProxy;
-        let dialect: Mandarine.ORM.Dialect.Dialects = Mandarine.Global.getMandarineConfiguration().mandarine.dataSource.dialect;
-
-        switch(dialect) {
-            case Mandarine.ORM.Dialect.Dialects.POSTGRESQL:
-                repositoryProxy = new PostgresRepositoryProxy<any>(repositoryInstance.extraData.entity);
-            break;
-            default:
-                throw new Error(`${dialect} is not supported inside Mandarine's ORM`);
-            break;
+        let dialect: Mandarine.ORM.Dialect.Dialects = Mandarine.Global.getMandarineConfiguration().mandarine?.dataSource?.dialect;
+        
+        if(dialect) {
+            switch(dialect) {
+                case Mandarine.ORM.Dialect.Dialects.POSTGRESQL:
+                    repositoryProxy = new PostgresRepositoryProxy<any>(repositoryInstance.extraData.entity);
+                break;
+                default:
+                    throw new Error(`${dialect} is not supported inside Mandarine's ORM`);
+                break;
+            }
         }
 
         repositoryMethods.forEach((methodName) => {

--- a/main-core/utils/commonUtils.ts
+++ b/main-core/utils/commonUtils.ts
@@ -33,4 +33,8 @@ export class CommonUtils {
           return false;
         }
     }
+
+    public static setEnvironmentVariablesFromObject(object: object) {
+        Object.keys(object).forEach((key) => Deno.env.set(key, object[key]));
+    }
 }


### PR DESCRIPTION
Close #51 .
You can now create a file called `mandarine.json` in your current working directory.
This file can take the following structure
```json
        propertiesFilePath: string;
        denoEnv: {
            [prop: string]: string
        }
```

`propertiesFilePath` defines the path of your **properties.json** file without having to necessarily have `./src/main/resources/properties.json` which is the default location

`denoEnv` allows you to define environmental variables.