### PR TITLE
Mandarine is now fully integrated with deno 1.2.0. Note that changes …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        deno: ["v1.2.0", "v1.1.2", "v1.1.1"]
+        deno: ["v1.2.0"]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }}
       - name: run tests
-        run: deno test -c tsconfig.json --allow-all
+        run: deno test -c tsconfig.json --reload --allow-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        deno: ["v1.1.3", "v1.1.2", "v1.1.1"]
+        deno: ["v1.2.0", "v1.1.2", "v1.1.1"]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-export { Application, Cookies, Request, Router, Context, Middleware, isHttpError, Status, FormDataReader } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/oak/5.3.1/mod.ts";
+export { Application, Cookies, Request, Router, Context, Middleware, isHttpError, Status, FormDataReader } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/oak/6.0.0/mod.ts";

--- a/logger/log.ts
+++ b/logger/log.ts
@@ -1,6 +1,6 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { bold, green, magenta, red, yellow } from "https://deno.land/std/fmt/colors.ts";
+import { bold, green, magenta, red, yellow } from "https://deno.land/std@0.61.0/fmt/colors.ts";
 
 export interface LogOptions {
     logDuringTesting: string;

--- a/main-core/mandarineConstants.ts
+++ b/main-core/mandarineConstants.ts
@@ -2,7 +2,7 @@
 
 export class MandarineConstants {
 
-    public static RELEASE_VERSION = "1.2.0";
+    public static RELEASE_VERSION = "1.2.1";
 
     public static readonly REFLECTION_MANDARINE_INJECTION_FIELD = "mandarine-method-di-field";
     public static readonly REFLECTION_MANDARINE_METHOD_ROUTE = "mandarine-method-route";

--- a/main-core/mandarineLoading.ts
+++ b/main-core/mandarineLoading.ts
@@ -1,6 +1,6 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { rgb8 } from "https://deno.land/std/fmt/colors.ts";
+import { rgb8 } from "https://deno.land/std@0.61.0/fmt/colors.ts";
 import { Log } from "../logger/log.ts";
 import { MandarineCore } from "./mandarineCore.ts";
 

--- a/main-core/utils/commonUtils.ts
+++ b/main-core/utils/commonUtils.ts
@@ -1,6 +1,6 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { v4 } from "https://deno.land/std/uuid/mod.ts";
+import { v4 } from "https://deno.land/std@0.61.0/uuid/mod.ts";
 
 export class CommonUtils {
     public static generateUUID(): string {

--- a/main-core/utils/httpUtils.ts
+++ b/main-core/utils/httpUtils.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { decoder } from "https://deno.land/std/encoding/utf8.ts";
-import { assert } from "https://deno.land/std@0.60.0/testing/asserts.ts";
+import { decoder } from "https://deno.land/std@0.61.0/encoding/utf8.ts";
 import { Request } from "../../deps.ts";
 import { Log } from "../../logger/log.ts";
 import { Mandarine } from "../Mandarine.ns.ts";
@@ -48,7 +47,7 @@ export class HttpUtils {
           const c = cookie.split(";");
           for (const kv of c) {
             const [cookieKey, ...cookieVal] = kv.split("=");
-            assert(cookieKey != null);
+            if(!(cookieKey != null)) continue;
             const key = cookieKey.trim();
             out[key] = cookieVal.join("=");
           }

--- a/mvc-framework/core/interfaces/http/cookie.ts
+++ b/mvc-framework/core/interfaces/http/cookie.ts
@@ -1,0 +1,23 @@
+export interface Cookie {
+    /** Name of the cookie. */
+    name: string;
+    /** Value of the cookie. */
+    value: string;
+    /** Expiration date of the cookie. */
+    expires?: Date;
+    /** Max-Age of the Cookie. Must be integer superior to 0. */
+    maxAge?: number;
+    /** Specifies those hosts to which the cookie will be sent. */
+    domain?: string;
+    /** Indicates a URL path that must exist in the request. */
+    path?: string;
+    /** Indicates if the cookie is made using SSL & HTTPS. */
+    secure?: boolean;
+    /** Indicates that cookie is not accessible via JavaScript. **/
+    httpOnly?: boolean;
+    /** Allows servers to assert that a cookie ought not to
+     * be sent along with cross-site requests. */
+    sameSite?: "Strict" | "Lax" | "None";
+    /** Additional key value pairs with the form "key=value" */
+    unparsed?: string[];
+}

--- a/mvc-framework/core/middlewares/sessionMiddleware.ts
+++ b/mvc-framework/core/middlewares/sessionMiddleware.ts
@@ -1,6 +1,5 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { Cookie } from "https://deno.land/std/http/cookie.ts";
 import { Cookies } from "../../../deps.ts";
 import { Log } from "../../../logger/log.ts";
 import { Mandarine } from "../../../main-core/Mandarine.ns.ts";
@@ -27,7 +26,7 @@ export class SessionMiddleware {
 
     private createSessionContext(sessionContainerConfig: Mandarine.Security.Sessions.SessionContainer, context: any) {
         let sesId = sessionContainerConfig.genId();
-        let sessionCookie: Cookie = SessionsUtils.getCookieForSession(sessionContainerConfig, sesId);
+        let sessionCookie: Mandarine.MandarineMVC.Cookie = SessionsUtils.getCookieForSession(sessionContainerConfig, sesId);
 
         context.cookies.set(sessionCookie.name, sessionCookie.value, {
             domain: sessionCookie.domain,
@@ -61,7 +60,7 @@ export class SessionMiddleware {
             sesId = sessionCookieName.split(':')[1];
             let digestData = cookiesFromRequest[sessionCookieName]; // Necessary to verify the signature of the cookie.
             
-            let sessionCookie: Cookie = SessionsUtils.getCookieForSession(sessionContainerConfig, sesId);
+            let sessionCookie: Mandarine.MandarineMVC.Cookie = SessionsUtils.getCookieForSession(sessionContainerConfig, sesId);
 
             const cookieDataForSignature: string = `${sessionContainerConfig.sessionPrefix}:${sesId}=${sesId}`;
 

--- a/mvc-framework/core/utils/mandarine/routingUtils.ts
+++ b/mvc-framework/core/utils/mandarine/routingUtils.ts
@@ -1,8 +1,6 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { ServerRequest } from "https://deno.land/std/http/server.ts";
 import { Mandarine } from "../../../../main-core/Mandarine.ns.ts";
-import { ControllerComponent } from "../../internal/components/routing/controllerContext.ts";
 
 /**
  * Contains all the util methods that are related to the router and routings
@@ -29,20 +27,5 @@ export class RoutingUtils {
 
     public static getRouteParamPattern(route: string): RegExp  {
         return new RegExp(route.replace(/:[^\s/]+/g, '([\\w-]+)'));
-    }
-
-    public static getRouteParamValues(controllerComponent: ControllerComponent, routeAction: Mandarine.MandarineMVC.Routing.RoutingAction, request: ServerRequest): any {
-        if(routeAction.routeParams == (null || undefined)) return null;
-        if(routeAction.routeParams.length == 0) return null;
-        let paramValues: any = new URL("http://localhost" + request.url).pathname.match(RoutingUtils.getRouteParamPattern(controllerComponent.getActionRoute(routeAction)));
-        
-        if(paramValues == null) return null;
-
-        let objectOfValues = {};
-        for (var i = 1; i < paramValues.length; i++) {
-            objectOfValues[routeAction.routeParams[i - 1].routeName] = paramValues[i];
-        }
-
-        return objectOfValues;
     }
 }

--- a/mvc-framework/mandarine-mvc.ns.ts
+++ b/mvc-framework/mandarine-mvc.ns.ts
@@ -4,6 +4,7 @@ import { Context } from "../deps.ts";
 import { DI } from "../main-core/dependency-injection/di.ns.ts";
 import { Mandarine } from "../mod.ts";
 import { RenderEngineClass } from "./core/modules/view-engine/renderEngine.ts";
+import { Cookie as MandarineCookie } from "./core/interfaces/http/cookie.ts"
 
 /**
 * This namespace contains all the essentials for Mandarine MVC to work
@@ -575,6 +576,9 @@ export namespace MandarineMvc {
         name: string,
         isFile: boolean
     };
+
+    export interface Cookie extends MandarineCookie {
+    }
 
     /**
      * Refers to all the information that the rendering engine needs to work out.

--- a/security-core/mandarine-security.ns.ts
+++ b/security-core/mandarine-security.ns.ts
@@ -1,6 +1,6 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { Cookie } from "https://deno.land/std/http/cookie.ts";
+import { Cookie } from "../mvc-framework/core/interfaces/http/cookie.ts";
 
 /**
  * Contains all the essentials for Mandarine's security core to work

--- a/security-core/utils/securityUtils.ts
+++ b/security-core/utils/securityUtils.ts
@@ -1,6 +1,5 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { assert } from "https://deno.land/std@0.60.0/testing/asserts.ts";
 import { HmacSha256 } from "../hash/sha256.ts";
 
 // Part of this class is a fraction of https://github.com/oakserver/oak/blob/master/tssCompare.ts
@@ -9,7 +8,7 @@ import { HmacSha256 } from "../hash/sha256.ts";
  */
 export class SecurityUtils {
     public static compareArrayBuffer(a: ArrayBuffer, b: ArrayBuffer): boolean {
-        assert(a.byteLength === b.byteLength, "ArrayBuffer lengths must match.");
+        if(!(a.byteLength === b.byteLength)) throw new Error("ArrayBuffer lengths must match.");
         const va = new DataView(a);
         const vb = new DataView(b);
         const length = va.byteLength;

--- a/security-core/utils/sessions.util.ts
+++ b/security-core/utils/sessions.util.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { Cookie } from "https://deno.land/std/http/cookie.ts";
 import { KeyStack } from "../keyStack.ts";
 import { MandarineSecurity } from "../mandarine-security.ns.ts";
+import { Cookie } from "../../mvc-framework/core/interfaces/http/cookie.ts";
 
 /**
  * Contains all the util methods used by the session middleware

--- a/tests/mod.ts
+++ b/tests/mod.ts
@@ -1,5 +1,5 @@
-export { Orange, Test } from "https://deno.land/x/orange@v0.2.7/mod.ts";
-export * as DenoAsserts from "https://deno.land/std@0.60.0/testing/asserts.ts"; 
+export { Orange, Test } from "https://x.nest.land/Orange@0.2.6/mod.ts";
+export * as DenoAsserts from "https://deno.land/std@0.61.0/testing/asserts.ts"; 
 
 // Mocking a decorator will give us "design:paramtypes", otherwise it will fail
 export function mockDecorator() {


### PR DESCRIPTION
Mandarine is now fully integrated with deno 1.2.0. Note that changes to external modules like (mandarine-postgres) and oak 6.0.0 were required.