### PR TITLE
Bugfix/fix route hierarchy

### DIFF
--- a/mvc-framework/core/middlewares/resourceHandlerMiddleware.ts
+++ b/mvc-framework/core/middlewares/resourceHandlerMiddleware.ts
@@ -45,8 +45,13 @@ export const ResourceHandlerMiddleware = (): Middleware => {
                         }
                         
                         resource = (index) ? resource : `${resourceHandlerLocation}/${resource}`;
-                        context.response.body = resourceHandler.resourceResolver.resolve(context, resource);
-                        (context as any).isResource = true;
+                        const resourceData = resourceHandler.resourceResolver.resolve(context, resource);
+                        context.response.body = resourceData;
+                        
+                        if(resourceData) {
+                            // Resource is valid
+                            (context as any).isResource = true;
+                        }
                     }
                 }
             }

--- a/mvc-framework/core/middlewares/resourceHandlerMiddleware.ts
+++ b/mvc-framework/core/middlewares/resourceHandlerMiddleware.ts
@@ -46,6 +46,7 @@ export const ResourceHandlerMiddleware = (): Middleware => {
                         
                         resource = (index) ? resource : `${resourceHandlerLocation}/${resource}`;
                         context.response.body = resourceHandler.resourceResolver.resolve(context, resource);
+                        (context as any).isResource = true;
                     }
                 }
             }

--- a/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
+++ b/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
@@ -98,7 +98,12 @@ export class MandarineMvcFrameworkStarter {
 
         let availableMiddlewares: Array<MiddlewareComponent> = Mandarine.Global.getMiddleware();
 
-        let responseHandler = async (context) => {
+        let responseHandler = async (context, next) => {
+
+            if(context.isResource) {
+                await next();
+                return;
+            }
 
             this.preRequestInternalMiddlewares(context, routingAction, controllerComponent); // Execute internal middleware like sessions
             let continueRequest: boolean = await this.executeUserMiddlewares(true, availableMiddlewares, context, routingAction); // If the user has any middleware, execute it

--- a/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
+++ b/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
@@ -109,7 +109,6 @@ export class MandarineMvcFrameworkStarter {
             let continueRequest: boolean = await this.executeUserMiddlewares(true, availableMiddlewares, context, routingAction); // If the user has any middleware, execute it
 
             if(continueRequest) {
-
                 await requestResolver(routingAction, context);
 
                 MandarineMvcFrameworkStarter.assignContentType(context);
@@ -117,8 +116,13 @@ export class MandarineMvcFrameworkStarter {
                 this.executeUserMiddlewares(false, availableMiddlewares, context, routingAction);
                 this.postRequestInternalMiddlewares(context);
 
-                await next();
+                if(context.request.url.pathname === routingAction.route) {
+                    return;
+                } else {
+                    await next();
+                }
             }
+            console.log(context.request.url.pathname, routingAction, context.mynum);
         };
 
         switch(routingAction.actionType) {

--- a/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
+++ b/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
@@ -116,6 +116,8 @@ export class MandarineMvcFrameworkStarter {
 
                 this.executeUserMiddlewares(false, availableMiddlewares, context, routingAction);
                 this.postRequestInternalMiddlewares(context);
+
+                await next();
             }
         };
 

--- a/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
+++ b/mvc-framework/engine/mandarineMvcFrameworkStarter.ts
@@ -122,7 +122,7 @@ export class MandarineMvcFrameworkStarter {
                     await next();
                 }
             }
-            console.log(context.request.url.pathname, routingAction, context.mynum);
+
         };
 
         switch(routingAction.actionType) {

--- a/mvc-framework/mandarineMVC.ts
+++ b/mvc-framework/mandarineMVC.ts
@@ -68,9 +68,9 @@ export class MandarineMVC {
         });
         
         let app: Application = new Application()
+        .use(ResourceHandlerMiddleware())
         .use(starter.getRouter().routes())
         .use(starter.getRouter().allowedMethods())
-        .use(ResourceHandlerMiddleware())
         .use(async (ctx, next) => {
             await next();
         });

--- a/tests/integration-tests/files/sessionCounter.ts
+++ b/tests/integration-tests/files/sessionCounter.ts
@@ -1,7 +1,7 @@
-import { Controller } from "../../../mvc-framework/core/decorators/stereotypes/controller/controller.ts";
-import { GET } from "../../../mvc-framework/core/decorators/stereotypes/controller/routingDecorator.ts";
-import { Session, RequestParam } from "../../../mvc-framework/core/decorators/stereotypes/controller/parameterDecorator.ts";
 import { MandarineCore } from "../../../mod.ts";
+import { Controller } from "../../../mvc-framework/core/decorators/stereotypes/controller/controller.ts";
+import { RequestParam, Session } from "../../../mvc-framework/core/decorators/stereotypes/controller/parameterDecorator.ts";
+import { GET } from "../../../mvc-framework/core/decorators/stereotypes/controller/routingDecorator.ts";
 
 @Controller()
 class TestController {
@@ -17,6 +17,10 @@ class TestController {
         }
     }
 
+    @GET('/(.*)')
+    public ok() {
+        return "Ok";
+    }
 }
 
 new MandarineCore().MVC().run({ port: 8084 });


### PR DESCRIPTION
Fixing route hierarchy.

If A resource with the same name of a route exists then we use the resource.
If A Resource doesn't exist with the current route, then we look for the handler of the route.
If a Wildcard route exists `Ex: (.*)` and also more routes exist, we take priority for the existent routes and **then** for the wildcard. So if `/hello-world` exists along with a `/(.*)`, we resolve for `/hello-world` and we ignore the wildcard.