### PR TITLE
CI now for v1.2.2 and v1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        deno: ["v1.2.1", "v1.2.0"]
+        deno: ["v1.2.2", "v1.2.1"]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Updating CI CI now for v1.2.2 and v1.2.1