### PR TITLE
Error is now thrown if environmental variable from `denoEnv` in `mand…

### DIFF
--- a/main-core/Mandarine.ns.ts
+++ b/main-core/Mandarine.ns.ts
@@ -225,7 +225,7 @@ export namespace Mandarine {
                     }
 
                 } catch (error) {
-                    // DO NOTHING
+                    MandarineUtils.reThrowError(error);
                 }
             }
 

--- a/main-core/exceptions/mandarineException.ts
+++ b/main-core/exceptions/mandarineException.ts
@@ -8,8 +8,9 @@ export class MandarineException extends Error {
     public static INVALID_PROPERTY_FILE: string = "The property file (%propertyFile%) you are trying to use is either invalid or could not be parsed";
     public static INVALID_STATIC_FOLDER: string = "Found static folder (%staticFolder%) but the path is either invalid or does not exist.";
     public static ROUTE_ALREADY_EXIST: string = "Mandarine cannot be initialized because a route ($s) already exists. Routes must be different.";
+    public static ENV_VARIABLE_ISNT_STRING: string = "The value for environmental variable '%s' cannot be read. Only arrays or strings are allowed.";
   
-    constructor(public message: string) {
+    constructor(public message: string, public superAlert: boolean = false) {
       super(message);
       this.name = "MandarineException";
       this.stack = (this).stack;

--- a/main-core/utils/commonUtils.ts
+++ b/main-core/utils/commonUtils.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { v4 } from "https://deno.land/std@0.62.0/uuid/mod.ts";
+import { MandarineException } from "../exceptions/mandarineException.ts";
 
 export class CommonUtils {
     public static generateUUID(): string {
@@ -37,7 +38,11 @@ export class CommonUtils {
     }
 
     public static setEnvironmentVariablesFromObject(object: object) {
-        Object.keys(object).forEach((key) => Deno.env.set(key, object[key].toString()));
+        Object.keys(object).forEach((key) => {
+            const value = object[key];
+            if(typeof value === 'object' && !Array.isArray(value)) throw new MandarineException(MandarineException.ENV_VARIABLE_ISNT_STRING.replace('%s', key), true);
+            Deno.env.set(key, value.toString());
+        });
     }
 
     public static sleep(seconds: number) 

--- a/main-core/utils/mandarineUtils.ts
+++ b/main-core/utils/mandarineUtils.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { Mandarine } from "../Mandarine.ns.ts";
+import { MandarineException } from "../exceptions/mandarineException.ts";
 
 export class MandarineUtils {
 
@@ -33,5 +34,13 @@ export class MandarineUtils {
         })
       
         return obj;
+    }
+
+    public static reThrowError(error: Error) {
+        if(error instanceof MandarineException) {
+            if(error.superAlert) {
+                throw error;
+            }
+        }
     }
 }


### PR DESCRIPTION
Error is now thrown if environmental variable from `denoEnv` in `mandarine.json` is not a string or array.
close #122 