### PR TITLE
Deno 1.2.3, downgrading to 0.62.0. 0.64.0 still not working properly …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        deno: ["v1.2.2", "v1.2.1"]
+        deno: ["v1.2.3", "v1.2.2"]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-export { Application, Cookies, Request, Router, Context, Middleware, isHttpError, Status, FormDataReader, send } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/oak/6.0.0/mod.ts";
+export { Application, Cookies, Request, Router, Context, Middleware, isHttpError, Status, FormDataReader, send } from "https://raw.githubusercontent.com/mandarineorg/mandarinets-modules/master/oak/6.0.1/mod.ts";

--- a/tests/copyright_test.ts
+++ b/tests/copyright_test.ts
@@ -1,10 +1,10 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-import { Test, DenoAsserts, Orange } from "./mod.ts";
-import { expandGlobSync, WalkEntry } from "https://deno.land/std@0.64.0/fs/mod.ts";
-import { readLines } from "https://deno.land/std@0.64.0/io/mod.ts";
+import { expandGlobSync } from "https://deno.land/std@0.62.0/fs/mod.ts";
+import { readLines } from "https://deno.land/std@0.62.0/io/mod.ts";
 import { MandarineConstants } from "../main-core/mandarineConstants.ts";
 import { CommonUtils } from "../main-core/utils/commonUtils.ts";
+import { Test } from "./mod.ts";
 
 export class CopyrightTest {
 


### PR DESCRIPTION
Deno 1.2.3, downgrading to 0.62.0. 0.64.0 still not working properly with Mandarine.