### PR TITLE
(Docs) Added a how to test explanation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,10 +6,11 @@
     - Make sure no one else is working on it already
     - Assign it to you
     - Investigate everything you have to investigate
-    
 ### Self-dependency
 We want to be as self-dependent as we can, this means, the less external modules or third-party codes we have, the better.
-
+# How to run
+1) Start by cloning this repository into your local machine.
+2) To run the tests, use the command `deno test -c tsconfig.json --allow-all`
 # Branch
   - When starting to work on an issue, you **must always** branch off of `develop`
 # Submitting a pull request

--- a/docs/web/mandarine/faq.md
+++ b/docs/web/mandarine/faq.md
@@ -16,6 +16,11 @@ See our [contributing guidelines](https://github.com/mandarineorg/mandarinets/bl
 ## Why do I need a `tsconfig.json`?
 Mandarine relies on some typescript configuration properties that are not part of Deno's default values.
 
+## When do I need a `tsconfig.json`?
+To be able to run any deno command like `deno run` or `deno test` you will need
+to provide a `tsconfig.json` file using the `--config` flag. (e.g. `deno test
+--config tsconfig.json`). [Click here](https://www.mandarinets.org/docs/master/mandarine/main-configuration#typescript-configuration) to find Mandarine's tsconfig.json.
+
 &nbsp;
 
 ## I am getting a lot of compiling errors


### PR DESCRIPTION
When trying to run Mandarine's test suite, i did not find at first an explanation on how to run the tests. Considering that there is a `contributing.md` file, we should explain the command there for future contributors.