### PR TITLE
Middleware targetting not only routes (methods http handlers) but con…

### DIFF
--- a/main-core/components/middleware-component/middlewareComponent.ts
+++ b/main-core/components/middleware-component/middlewareComponent.ts
@@ -3,6 +3,7 @@
 import { MandarineException } from "../../exceptions/mandarineException.ts";
 import { Mandarine } from "../../Mandarine.ns.ts";
 import { MiddlewareTarget } from "./middlewareTarget.ts";
+import { MiddlewareUtil } from "../../utils/components/middlewareUtil.ts";
 
 /**
 * This class is used in the DI Container for Mandarine to store components annotated as @Middleware
@@ -21,9 +22,7 @@ export class MiddlewareComponent implements Mandarine.MandarineCore.ComponentCom
 
     public verifyHandlerImplementation() {
         let middlewareTarget: MiddlewareTarget = <MiddlewareTarget> this.classHandler;
-        let isImplementationValid = (middlewareTarget.onPostRequest && typeof middlewareTarget.onPostRequest === 'function') && (middlewareTarget.onPreRequest && typeof middlewareTarget.onPreRequest === 'function');
-        
-        if(isImplementationValid == undefined) throw new MandarineException(MandarineException.MIDDLEWARE_NON_VALID_IMPL);
+        MiddlewareUtil.verifyImplementation(middlewareTarget);
     }
 
     public getName() {

--- a/main-core/components/middleware-component/middlewareTarget.ts
+++ b/main-core/components/middleware-component/middlewareTarget.ts
@@ -26,3 +26,8 @@ export interface MiddlewareTarget {
     onPreRequest(...args): boolean;
     onPostRequest(...args): void;
 }
+
+export interface NonComponentMiddlewareTarget {
+    onPreRequest(request: any, response: any): boolean;
+    onPostRequest(request: any, response: any): void;
+}

--- a/main-core/decorators/stereotypes/middleware/Middleware.ts
+++ b/main-core/decorators/stereotypes/middleware/Middleware.ts
@@ -11,7 +11,7 @@ import { MainCoreDecoratorProxy } from "../../../proxys/mainCoreDecorator.ts";
  * `@Middleware(regexRoute: RegExp)
  *  Target: class`
  */
-export const Middleware = (regexRoute: RegExp): Function => {
+export const Middleware = (regexRoute?: RegExp): Function => {
     return (target: any, methodName: string, index: number) => {
         MainCoreDecoratorProxy.registerMandarinePoweredComponent(target, Mandarine.MandarineCore.ComponentTypes.MIDDLEWARE, {
             regexRoute: regexRoute

--- a/main-core/dependency-injection/diFactory.ts
+++ b/main-core/dependency-injection/diFactory.ts
@@ -203,4 +203,14 @@ export class DependencyInjectionFactory {
     public getInjectable(type: any) {
         return this.getDependency(type);
     }
+
+    /**
+     * Get component of dependency by Type
+     */
+    public getComponentByType(type: any) {
+        let component = ApplicationContext.getInstance().getComponentsRegistry().getComponentByHandlerType(type);
+        if(component != (null || undefined) && component.componentType !== Mandarine.MandarineCore.ComponentTypes.MANUAL_COMPONENT) {
+            return component.componentInstance;
+        }
+    }
 }

--- a/main-core/engine/mandarineTSFrameworkEngineMethods.ts
+++ b/main-core/engine/mandarineTSFrameworkEngineMethods.ts
@@ -31,7 +31,8 @@ export class MandarineTSFrameworkEngineMethods {
                 let componentInstance: MiddlewareComponent = component.componentInstance;
 
                 componentInstance.verifyHandlerImplementation();
-
+                
+                if(!componentInstance.regexRoute) return;
                 middleware.push(componentInstance);
             });
 

--- a/main-core/exceptions/mandarineException.ts
+++ b/main-core/exceptions/mandarineException.ts
@@ -2,7 +2,7 @@
 
 export class MandarineException extends Error {
 
-    public static MIDDLEWARE_NON_VALID_IMPL: string = "Middleware cannot be initialized because it is not an implemention of 'MiddlewareTarget'";
+    public static MIDDLEWARE_NON_VALID_IMPL: string = "Middleware cannot be initialized because it is not a valid implemention of 'MiddlewareTarget'";
     public static INVALID_TEMPLATE: string = "The template %templatePath% could not be initialized. This may be caused because the path is incorrect.";
     public static UNDEFINED_TEMPLATE: string = "The template could not be initialized because its path is undefined";
     public static INVALID_PROPERTY_FILE: string = "The property file (%propertyFile%) you are trying to use is either invalid or could not be parsed";
@@ -14,6 +14,8 @@ export class MandarineException extends Error {
     public static UNKNOWN_OVERRIDEN: string = "Mandarine could not execute internal override because %s is not of a known native component.";
     public static ON_INITIALIZATION_OVERRIDEN: string = "The method `onInitialization` cannot be overriden because it is a Mandarine reserved method.";
     public static INVALID_ALLOWONLY_DECORATOR_PERMISSIONS: string = "Decorator `@AllowOnly` only receives an array or a security expression (string).";
+    public static INVALID_MIDDLEWARE_LIST_ANNOTATION: string = "Decorator `@UseMiddleware` is being used but a list of undefined values was passed.";
+    public static INVALID_MIDDLEWARE_UNDEFINED: string = "Middleware cannot be initialized because it is undefined.";
   
     constructor(public message: string, public superAlert: boolean = false) {
       super(message);

--- a/main-core/mandarineConstants.ts
+++ b/main-core/mandarineConstants.ts
@@ -18,6 +18,7 @@ export class MandarineConstants {
     public static readonly REFLECTION_MANDARINE_METHOD_ROUTE_RENDER = "mandarine-method-route-render";
     public static readonly REFLECTION_HTTP_ACTION_KEY = "httpAction";
     public static readonly REFLECTION_MANDARINE_SECURITY_ALLOWONLY_DECORATOR = "mandarine-security-allow-only";
+    public static readonly REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR = "mandarine-use-middleware";
 
     // SECURITY
     public static readonly SECURITY_AUTH_COOKIE_NAME = "MDAUTHID";

--- a/main-core/utils/components/middlewareUtil.ts
+++ b/main-core/utils/components/middlewareUtil.ts
@@ -1,0 +1,12 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { MiddlewareTarget } from "../../components/middleware-component/middlewareTarget.ts";
+import { MandarineException } from "../../exceptions/mandarineException.ts";
+
+export class MiddlewareUtil {
+    public static verifyImplementation(middleware: MiddlewareTarget) {
+        let isImplementationValid = (middleware.onPostRequest && typeof middleware.onPostRequest === 'function') && (middleware.onPreRequest && typeof middleware.onPreRequest === 'function');
+        
+        if(isImplementationValid == undefined) throw new MandarineException(MandarineException.MIDDLEWARE_NON_VALID_IMPL);
+    }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -13,7 +13,7 @@ export { Component } from "./main-core/decorators/stereotypes/component/componen
 export { Configuration } from "./main-core/decorators/stereotypes/configuration/configuration.ts";
 export { Service } from "./main-core/decorators/stereotypes/service/service.ts";
 export { Middleware } from "./main-core/decorators/stereotypes/middleware/Middleware.ts";
-export { MiddlewareTarget } from "./main-core/components/middleware-component/middlewareTarget.ts";
+export { MiddlewareTarget, NonComponentMiddlewareTarget } from "./main-core/components/middleware-component/middlewareTarget.ts";
 export { Inject } from "./main-core/dependency-injection/decorators/Inject.ts";
 export { Injectable } from "./main-core/dependency-injection/decorators/injectable.ts";
 export { MandarineCore } from "./main-core/mandarineCore.ts";
@@ -41,3 +41,4 @@ export { PromiseRepeater } from "./pluggins/promiseRepeater.ts";
 export { MandarineSessionHandler } from "./main-core/mandarine-native/sessions/mandarineDefaultSessionStore.ts";
 
 export { AllowOnly } from "./security-core/core/decorators/allowOnly.ts";
+export { UseMiddleware } from "./mvc-framework/core/decorators/stereotypes/controller/useMiddleware.ts";

--- a/mvc-framework/core/decorators/stereotypes/controller/useMiddleware.ts
+++ b/mvc-framework/core/decorators/stereotypes/controller/useMiddleware.ts
@@ -1,0 +1,12 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { NonComponentMiddlewareTarget } from "../../../../../main-core/components/middleware-component/middlewareTarget.ts";
+import { MandarineException } from "../../../../../main-core/exceptions/mandarineException.ts";
+import { MVCDecoratorsProxy } from "../../../proxys/mvcCoreDecorators.ts";
+
+export const UseMiddleware = (middlewareList: Array<NonComponentMiddlewareTarget | any>) => {
+    return (target: any, methodName?: string) => {
+        if(!middlewareList) throw new MandarineException(MandarineException.INVALID_MIDDLEWARE_LIST_ANNOTATION);
+        MVCDecoratorsProxy.registerUseMiddlewareDecorator(target, middlewareList, methodName);
+    }
+}

--- a/mvc-framework/core/proxys/mvcCoreDecorators.ts
+++ b/mvc-framework/core/proxys/mvcCoreDecorators.ts
@@ -8,6 +8,7 @@ import { Reflect } from "../../../main-core/reflectMetadata.ts";
 import { ComponentUtils } from "../../../main-core/utils/componentUtils.ts";
 import { ReflectUtils } from "../../../main-core/utils/reflectUtils.ts";
 import { AnnotationMetadataContext } from "../interfaces/mandarine/mandarineAnnotationMetadataContext.ts";
+import { NonComponentMiddlewareTarget } from "../../../main-core/components/middleware-component/middlewareTarget.ts";
 
 export class MVCDecoratorsProxy {
 
@@ -31,6 +32,17 @@ export class MVCDecoratorsProxy {
         } else {
             let corsAnnotationMetadataName: string = `${MandarineConstants.REFLECTION_MANDARINE_CONTROLLER_CORS_MIDDLEWARE}:${methodName}`;
             Reflect.defineMetadata(corsAnnotationMetadataName, newCors, targetClass, methodName);
+        }
+    }
+
+    public static registerUseMiddlewareDecorator(targetClass: any, middlewareList: Array<NonComponentMiddlewareTarget | any>, methodName: string) {
+        let isMethod: boolean = methodName != null;
+        if(!isMethod) {
+            let useMiddlewareAnnotationName: string = `${MandarineConstants.REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR}`;
+            Reflect.defineMetadata(useMiddlewareAnnotationName, [...middlewareList], targetClass);
+        } else {
+            let useMiddlewareAnnotationName: string = `${MandarineConstants.REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR}:${methodName}`;
+            Reflect.defineMetadata(useMiddlewareAnnotationName, [...middlewareList], targetClass, methodName);
         }
     }
 

--- a/mvc-framework/mandarine-mvc.ns.ts
+++ b/mvc-framework/mandarine-mvc.ns.ts
@@ -7,6 +7,8 @@ import { Mandarine } from "../mod.ts";
 import { Cookie as MandarineCookie } from "./core/interfaces/http/cookie.ts";
 import { MandarineMVCContext } from "./core/mandarineMvcContext.ts";
 import { RenderEngineClass } from "./core/modules/view-engine/renderEngine.ts";
+import { NonComponentMiddlewareTarget } from "../main-core/components/middleware-component/middlewareTarget.ts";
+import { MiddlewareComponent } from "../main-core/components/middleware-component/middlewareComponent.ts";
 
 /**
 * This namespace contains all the essentials for Mandarine MVC to work
@@ -493,7 +495,8 @@ export namespace MandarineMvc {
         export interface RoutingOptions {
             responseStatus?: HttpStatusCode,
             cors?: CorsMiddlewareOption,
-            withPermissions?: Mandarine.Security.Auth.Permissions
+            withPermissions?: Mandarine.Security.Auth.Permissions,
+            middleware?: Array<NonComponentMiddlewareTarget | MiddlewareComponent>
         }
 
         /**

--- a/tests/integration-tests/files/middleware.ts
+++ b/tests/integration-tests/files/middleware.ts
@@ -1,0 +1,109 @@
+import { Service } from "../../../main-core/decorators/stereotypes/service/service.ts";
+import { MiddlewareTarget } from "../../../main-core/components/middleware-component/middlewareTarget.ts";
+import { Middleware } from "../../../main-core/decorators/stereotypes/middleware/Middleware.ts";
+import { Controller } from "../../../mvc-framework/core/decorators/stereotypes/controller/controller.ts";
+import { UseMiddleware } from "../../../mvc-framework/core/decorators/stereotypes/controller/useMiddleware.ts";
+import { GET } from "../../../mvc-framework/core/decorators/stereotypes/controller/routingDecorator.ts";
+import { RequestParam } from "../../../mvc-framework/core/decorators/stereotypes/controller/parameterDecorator.ts";
+import { MandarineCore } from "../../../main-core/mandarineCore.ts";
+
+@Service()
+export class MyService {
+    public calculate() {
+        return 5 + 5;
+    }
+}
+
+@Middleware()
+export class MyNonRegexMiddleware implements MiddlewareTarget {
+
+    constructor(public readonly myService: MyService) {}
+
+    public onPreRequest(@RequestParam() request) {
+        request["TEST_MIDDLEWARE"] = `Hello ${this.myService.calculate()}`;
+        return true;
+    }
+
+    public onPostRequest() {
+    }
+}
+
+
+@Controller()
+@UseMiddleware([MyNonRegexMiddleware])
+export class MyController {
+
+    @GET('/with-middleware-controller')
+    public handler(@RequestParam() request) {
+        return request;
+    }
+
+}
+
+
+@Controller()
+export class MyController2 {
+
+    @GET('/with-middleware-method')
+    @UseMiddleware([MyNonRegexMiddleware])
+    public handler(@RequestParam() request) {
+        return request;
+    }
+
+    @GET('/hello-world')
+    public handler3(@RequestParam() request) {
+        return request;
+    }
+
+}
+
+export const nonComponentMiddlewareContinueFalse = {
+    onPreRequest: (request, response) => {
+        request["TEST_MIDDLEWARE_NONCOMPONENT"] = "Superman"
+        response.body = {
+            request: request,
+            response: response
+        }
+        return false;
+    },
+    onPostRequest: (request, response) => {
+    }
+}
+
+export const nonComponentMiddlewareContinueTrue = {
+    onPreRequest: (request, response) => {
+        request["TEST_MIDDLEWARE_NONCOMPONENT"] = "Batman"
+        return true;
+    },
+    onPostRequest: (request, response) => {
+    }
+}
+
+@Controller()
+export class MyController3 {
+    @GET('/api/get-4')
+    @UseMiddleware([nonComponentMiddlewareContinueFalse, MyNonRegexMiddleware])
+    public handler3(@RequestParam() request) {
+        return request;
+    }
+
+    @GET('/api/get-5')
+    @UseMiddleware([nonComponentMiddlewareContinueFalse])
+    public handler5(@RequestParam() request) {
+        return request;
+    }
+
+    @GET('/api/get-6')
+    @UseMiddleware([])
+    public handler6(@RequestParam() request) {
+        return request;
+    }
+
+    @GET('/api/get-7')
+    @UseMiddleware([nonComponentMiddlewareContinueTrue])
+    public handler7(@RequestParam() request) {
+        return request;
+    }
+}
+
+new MandarineCore().MVC().run({ port: 2024 });

--- a/tests/integration-tests/files/middleware.ts
+++ b/tests/integration-tests/files/middleware.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { Service } from "../../../main-core/decorators/stereotypes/service/service.ts";
 import { MiddlewareTarget } from "../../../main-core/components/middleware-component/middlewareTarget.ts";
 import { Middleware } from "../../../main-core/decorators/stereotypes/middleware/Middleware.ts";

--- a/tests/integration-tests/middleware_test.ts
+++ b/tests/integration-tests/middleware_test.ts
@@ -1,0 +1,62 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
+import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+
+export class MiddlewareTest {
+
+    public MAX_COMPILATION_TIMEOUT_SECONDS = 12;
+
+    constructor() {
+        Orange.setOptions(this, {
+            hooks: {
+                beforeEach: () => CommonUtils.sleep(2)
+            }
+        })
+    }
+
+    @Test({
+        name: "Test Endpoints from `files/middleware.ts`",
+        description: "Test all endpoints in file, and verifies middleware references are working fine"
+    })
+    public async testManualInjectionEndpoint() {
+        let cmd = Deno.run({
+            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/middleware.ts`],
+            stdout: "null",
+            stderr: "null",
+            stdin: "null"
+        });
+
+        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+
+        let test1 = (await (await fetch("http://localhost:2024/with-middleware-controller")).json());
+        let test2 = (await (await fetch("http://localhost:2024/with-middleware-method")).json());
+        let test3 = (await (await fetch("http://localhost:2024/hello-world")).json());
+        let test4 = (await (await fetch("http://localhost:2024/api/get-4")).json());
+        let test5 = (await (await fetch("http://localhost:2024/api/get-5")).json());
+        let test6 = (await (await fetch("http://localhost:2024/api/get-6")).json());
+        let test7 = (await (await fetch("http://localhost:2024/api/get-7")).json());
+
+        let errorThrown = undefined;
+        try {
+            DenoAsserts.assertEquals(test1["TEST_MIDDLEWARE"], "Hello 10");
+            DenoAsserts.assertEquals(test2["TEST_MIDDLEWARE"], "Hello 10");
+            DenoAsserts.assertEquals(test3["TEST_MIDDLEWARE"], undefined);
+            DenoAsserts.assertEquals(test4.request["TEST_MIDDLEWARE_NONCOMPONENT"], "Superman");
+            DenoAsserts.assertEquals(test4.request["TEST_MIDDLEWARE"], undefined);
+            DenoAsserts.assertEquals(test5.request["TEST_MIDDLEWARE_NONCOMPONENT"], "Superman");
+            DenoAsserts.assertEquals(test6["TEST_MIDDLEWARE"], undefined);
+            DenoAsserts.assertEquals(test6["TEST_MIDDLEWARE_NONCOMPONENT"], undefined);
+            DenoAsserts.assertEquals(test7["TEST_MIDDLEWARE_NONCOMPONENT"], "Batman");
+
+        } catch(error) {
+            errorThrown = error;
+        }
+        
+        cmd.close();
+        if(errorThrown != undefined) {
+            throw errorThrown;
+        }
+    }
+
+}

--- a/tests/unit-tests/httpHandlers_test.ts
+++ b/tests/unit-tests/httpHandlers_test.ts
@@ -75,7 +75,9 @@ export class HttpHandlersTest {
                 actionType: 0,
                 actionMethodName: "getRoute",
                 route: "/api-get",
-                routingOptions: {},
+                routingOptions: {
+                    middleware: []
+                },
                 initializationStatus: 1,
                 routeParams: [],
                 routeSignature: ["0", "api-get"]
@@ -85,7 +87,9 @@ export class HttpHandlersTest {
                 actionType: 1,
                 actionMethodName: "postRoute",
                 route: "/api-post",
-                routingOptions: {},
+                routingOptions: {
+                    middleware: []
+                },
                 initializationStatus: 1,
                 routeParams: [],
                 routeSignature: ["1", "api-post"]
@@ -95,7 +99,9 @@ export class HttpHandlersTest {
                 actionType: 2,
                 actionMethodName: "putRoute",
                 route: "/api-put",
-                routingOptions: {},
+                routingOptions: {
+                    middleware: []
+                },
                 initializationStatus: 1,
                 routeParams: [],
                 routeSignature: ["2", "api-put"]
@@ -105,7 +111,9 @@ export class HttpHandlersTest {
                 actionType: 4,
                 actionMethodName: "deleteRoute",
                 route: "/api-delete",
-                routingOptions: {},
+                routingOptions: {
+                    middleware: []
+                },
                 initializationStatus: 1,
                 routeParams: [],
                 routeSignature: ["4", "api-delete"]
@@ -115,7 +123,9 @@ export class HttpHandlersTest {
                 actionType: 3,
                 actionMethodName: "headRoute",
                 route: "/api-head",
-                routingOptions: {},
+                routingOptions: {
+                    middleware: []
+                },
                 initializationStatus: 1,
                 routeParams: [],
                 routeSignature: ["3", "api-head"]
@@ -125,7 +135,9 @@ export class HttpHandlersTest {
                 actionType: 6,
                 actionMethodName: "optionsRoute",
                 route: "/api-options",
-                routingOptions: {},
+                routingOptions: {
+                    middleware: []
+                },
                 initializationStatus: 1,
                 routeParams: [],
                 routeSignature: ["6", "api-options"]
@@ -135,7 +147,9 @@ export class HttpHandlersTest {
                 actionType: 5,
                 actionMethodName: "patchRoute",
                 route: "/api-patch",
-                routingOptions: {},
+                routingOptions: {
+                    middleware: []
+                },
                 initializationStatus: 1,
                 routeParams: [],
                 routeSignature: ["5", "api-patch"]
@@ -361,7 +375,6 @@ export class HttpHandlersTest {
         let controller: ControllerComponent = ApplicationContext.getInstance().getComponentsRegistry().get("MyController").componentInstance;
         let actions: Map<String, Mandarine.MandarineMVC.Routing.RoutingAction> = controller.getActions();
         let action = actions.get(controller.getActionName("getRoute"));
-        console.log(action);
         DenoAsserts.assertEquals(action.routingOptions.responseStatus, 301);
         DenoAsserts.assertEquals(controller.options.responseStatus, 400);
     }


### PR DESCRIPTION
Middleware targetting not only routes (methods http handlers) but controllers are now fully supported through the decorator `@UseMiddleware` which targets a class or http handler.