### PR TITLE
Support guards:

### DIFF
--- a/main-core/Mandarine.ns.ts
+++ b/main-core/Mandarine.ns.ts
@@ -466,7 +466,8 @@ export namespace Mandarine {
             CONFIGURATION,
             MIDDLEWARE,
             REPOSITORY,
-            MANUAL_COMPONENT
+            MANUAL_COMPONENT,
+            GUARDS
         };
 
         /**

--- a/main-core/components-registry/componentRegistry.ts
+++ b/main-core/components-registry/componentRegistry.ts
@@ -60,6 +60,9 @@ export class ComponentsRegistry implements Mandarine.MandarineCore.IComponentsRe
                 case Mandarine.MandarineCore.ComponentTypes.CATCH:
                     componentInstanceInitialized = new ComponentComponent(componentName, componentHandler, Mandarine.MandarineCore.ComponentTypes.CATCH, configuration);
                 break;
+                case Mandarine.MandarineCore.ComponentTypes.GUARDS:
+                    componentInstanceInitialized = new ComponentComponent(componentName, componentHandler, Mandarine.MandarineCore.ComponentTypes.GUARDS, configuration);
+                break;
             }
 
             this.components.set(componentName, {

--- a/main-core/decorators/stereotypes/guards/guard.ts
+++ b/main-core/decorators/stereotypes/guards/guard.ts
@@ -6,15 +6,13 @@ import { MainCoreDecoratorProxy } from "../../../proxys/mainCoreDecorator.ts";
 /**
  * **Decorator**
  * 
- * Register a component type Catch in the DI Container
+ * Register a Guard component for the DI Container
  *
- * `@Catch()
+ * `@Guard()
  *  Target: class`
  */
-export const Catch = (exception: any): Function => {
+export const Guard = (): Function => {
     return (target: any) => {
-        MainCoreDecoratorProxy.registerMandarinePoweredComponent(target, Mandarine.MandarineCore.ComponentTypes.CATCH, {
-            exceptionType: exception
-        }, undefined);
+        MainCoreDecoratorProxy.registerMandarinePoweredComponent(target, Mandarine.MandarineCore.ComponentTypes.GUARDS, {}, undefined);
     };
 };

--- a/main-core/exceptions/mandarineException.ts
+++ b/main-core/exceptions/mandarineException.ts
@@ -15,9 +15,11 @@ export class MandarineException extends Error {
     public static ON_INITIALIZATION_OVERRIDEN: string = "The method `onInitialization` cannot be overriden because it is a Mandarine reserved method.";
     public static INVALID_ALLOWONLY_DECORATOR_PERMISSIONS: string = "Decorator `@AllowOnly` only receives an array or a security expression (string).";
     public static INVALID_MIDDLEWARE_LIST_ANNOTATION: string = "Decorator `@UseMiddleware` is being used but a list of undefined values was passed.";
+    public static INVALID_GUARDS_LIST_ANNOTATION: string = "Decorator `@UseGuards` is being used but a list of undefined values was passed.";
     public static INVALID_MIDDLEWARE_UNDEFINED: string = "Middleware cannot be initialized because it is undefined.";
     public static INVALID_PIPE_LOCATION: string = "Pipes can only target parameters of a HTTP Handler";
     public static INVALID_PIPE_EXECUTION: string = "Pipe execution failed because it's either an invalid pipe or an exception was thrown during transformation";
+    public static INVALID_GUARD_EXECUTION: string = "A guard was found but it is not a valid mandarine-powered component nor a function";
   
     constructor(public message: string, public superAlert: boolean = false) {
       super(message);

--- a/main-core/internals/interfaces/guardTarget.ts
+++ b/main-core/internals/interfaces/guardTarget.ts
@@ -1,0 +1,25 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { Mandarine } from "../../Mandarine.ns.ts";
+
+/**
+   * Define the behavior of a user-side guard
+   * The guard target will be called at the time of a request.
+   * onGuard(requestContext, ...args) will be called before executing the endpoint.
+   * 
+   * If onGuard **returns false**, the endpoint's execution will be discarded.
+   * In order to keep the execution cycle going, onGuard must return true.
+   *
+   *        export class MyGuard implements GuardTarget {
+   *            onGuard(requestContext: Mandarine.Types.RequestContext) {
+   *                console.log("onGuard() called");
+   *                return true;
+   *            }
+   *        }
+   *
+   */
+export interface GuardTarget {
+  onGuard(requestContext: Mandarine.Types.RequestContext, ...args): boolean;
+}
+
+export type GuardTargetMethod = (requestContext: Mandarine.Types.RequestContext) => boolean;

--- a/main-core/internals/interfaces/middlewareTarget.ts
+++ b/main-core/internals/interfaces/middlewareTarget.ts
@@ -22,7 +22,7 @@
    *        }
    *
    */
-  export interface MiddlewareTarget {
+export interface MiddlewareTarget {
     onPreRequest(...args): boolean;
     onPostRequest(...args): void;
 }

--- a/main-core/mandarineConstants.ts
+++ b/main-core/mandarineConstants.ts
@@ -20,6 +20,7 @@ export class MandarineConstants {
     public static readonly REFLECTION_HTTP_ACTION_KEY = "httpAction";
     public static readonly REFLECTION_MANDARINE_SECURITY_ALLOWONLY_DECORATOR = "mandarine-security-allow-only";
     public static readonly REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR = "mandarine-use-middleware";
+    public static readonly REFLECTION_MANDARINE_USE_GUARDS_DECORATOR = "mandarine-use-guards";
 
     // SECURITY
     public static readonly SECURITY_AUTH_COOKIE_NAME = "MDAUTHID";

--- a/mod.ts
+++ b/mod.ts
@@ -46,3 +46,6 @@ export { AllowOnly } from "./security-core/core/decorators/allowOnly.ts";
 export { UseMiddleware } from "./mvc-framework/core/decorators/stereotypes/controller/useMiddleware.ts";
 
 export { ExceptionContext, ExceptionFilter } from "./main-core/internals/interfaces/exceptionFilter.ts";
+export { GuardTarget, GuardTargetMethod } from "./main-core/internals/interfaces/guardTarget.ts";
+
+export { UseGuards } from "./mvc-framework/core/decorators/stereotypes/controller/useGuards.ts";

--- a/mvc-framework/core/decorators/stereotypes/controller/useGuards.ts
+++ b/mvc-framework/core/decorators/stereotypes/controller/useGuards.ts
@@ -1,0 +1,12 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { MandarineException } from "../../../../../main-core/exceptions/mandarineException.ts";
+import { MVCDecoratorsProxy } from "../../../proxys/mvcCoreDecorators.ts";
+import { GuardTarget } from "../../../../../main-core/internals/interfaces/guardTarget.ts";
+
+export const UseGuards = (guardsList: Array<GuardTarget | any>) => {
+    return (target: any, methodName?: string) => {
+        if(!guardsList) throw new MandarineException(MandarineException.INVALID_GUARDS_LIST_ANNOTATION);
+        MVCDecoratorsProxy.registerUseGuardsDecorator(target, guardsList, methodName);
+    }
+}

--- a/mvc-framework/core/internal/components/routing/controllerContext.ts
+++ b/mvc-framework/core/internal/components/routing/controllerContext.ts
@@ -70,7 +70,8 @@ export class ControllerComponent {
             cors: MandarineConstants.REFLECTION_MANDARINE_CONTROLLER_CORS_MIDDLEWARE, 
             withPermissions: MandarineConstants.REFLECTION_MANDARINE_SECURITY_ALLOWONLY_DECORATOR,
             responseStatus: MandarineConstants.REFLECTION_MANDARINE_CONTROLLER_DEFAULT_HTTP_RESPONSE_CODE,
-            middleware: MandarineConstants.REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR
+            middleware: MandarineConstants.REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR,
+            guards: MandarineConstants.REFLECTION_MANDARINE_USE_GUARDS_DECORATOR
         };
         let metadataKeysFromClass: Array<any> = Reflect.getMetadataKeys(this.getClassHandlerType());
 
@@ -89,7 +90,8 @@ export class ControllerComponent {
             cors: MandarineConstants.REFLECTION_MANDARINE_CONTROLLER_CORS_MIDDLEWARE,
             withPermissions: MandarineConstants.REFLECTION_MANDARINE_SECURITY_ALLOWONLY_DECORATOR,
             responseStatus: MandarineConstants.REFLECTION_MANDARINE_CONTROLLER_DEFAULT_HTTP_RESPONSE_CODE,
-            middleware: MandarineConstants.REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR
+            middleware: MandarineConstants.REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR,
+            guards: MandarineConstants.REFLECTION_MANDARINE_USE_GUARDS_DECORATOR
         }
         if(!routeContext.options) routeContext.options = {};
 

--- a/mvc-framework/core/proxys/mvcCoreDecorators.ts
+++ b/mvc-framework/core/proxys/mvcCoreDecorators.ts
@@ -9,6 +9,7 @@ import { ComponentUtils } from "../../../main-core/utils/componentUtils.ts";
 import { ReflectUtils } from "../../../main-core/utils/reflectUtils.ts";
 import { AnnotationMetadataContext } from "../interfaces/mandarine/mandarineAnnotationMetadataContext.ts";
 import { NonComponentMiddlewareTarget } from "../../../main-core/internals/interfaces/middlewareTarget.ts";
+import { GuardTarget } from "../../../main-core/internals/interfaces/guardTarget.ts";
 
 export class MVCDecoratorsProxy {
 
@@ -43,6 +44,17 @@ export class MVCDecoratorsProxy {
         } else {
             let useMiddlewareAnnotationName: string = `${MandarineConstants.REFLECTION_MANDARINE_USE_MIDDLEWARE_DECORATOR}:${methodName}`;
             Reflect.defineMetadata(useMiddlewareAnnotationName, [...middlewareList], targetClass, methodName);
+        }
+    }
+
+    public static registerUseGuardsDecorator(targetClass: any, guardsList: Array<GuardTarget | any>, methodName: string) {
+        let isMethod: boolean = methodName != null;
+        if(!isMethod) {
+            let useMiddlewareAnnotationName: string = `${MandarineConstants.REFLECTION_MANDARINE_USE_GUARDS_DECORATOR}`;
+            Reflect.defineMetadata(useMiddlewareAnnotationName, [...guardsList], targetClass);
+        } else {
+            let useMiddlewareAnnotationName: string = `${MandarineConstants.REFLECTION_MANDARINE_USE_GUARDS_DECORATOR}:${methodName}`;
+            Reflect.defineMetadata(useMiddlewareAnnotationName, [...guardsList], targetClass, methodName);
         }
     }
 

--- a/mvc-framework/mandarine-mvc.ns.ts
+++ b/mvc-framework/mandarine-mvc.ns.ts
@@ -8,6 +8,7 @@ import { Cookie as MandarineCookie } from "./core/interfaces/http/cookie.ts";
 import { MandarineMVCContext } from "./core/mandarineMvcContext.ts";
 import { RenderEngineClass } from "./core/modules/view-engine/renderEngine.ts";
 import { NonComponentMiddlewareTarget } from "../main-core/internals/interfaces/middlewareTarget.ts";
+import { GuardTarget } from "../main-core/internals/interfaces/guardTarget.ts";
 
 /**
 * This namespace contains all the essentials for Mandarine MVC to work
@@ -495,7 +496,8 @@ export namespace MandarineMvc {
             responseStatus?: HttpStatusCode,
             cors?: CorsMiddlewareOption,
             withPermissions?: Mandarine.Security.Auth.Permissions,
-            middleware?: Array<NonComponentMiddlewareTarget | Mandarine.Types.MiddlewareComponent>
+            middleware?: Array<NonComponentMiddlewareTarget | Mandarine.Types.MiddlewareComponent>;
+            guards?: Array<Function | GuardTarget>
         }
 
         /**

--- a/tests/integration-tests/files/guards.ts
+++ b/tests/integration-tests/files/guards.ts
@@ -1,0 +1,81 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { Controller } from "../../../mvc-framework/core/decorators/stereotypes/controller/controller.ts";
+import { GET } from "../../../mvc-framework/core/decorators/stereotypes/controller/routingDecorator.ts";
+import { UseGuards } from "../../../mvc-framework/core/decorators/stereotypes/controller/useGuards.ts";
+import { Guard } from "../../../main-core/decorators/stereotypes/guards/guard.ts";
+import { GuardTarget, GuardTargetMethod } from "../../../main-core/internals/interfaces/guardTarget.ts";
+import { Mandarine } from "../../../main-core/Mandarine.ns.ts";
+import { MandarineCore } from "../../../main-core/mandarineCore.ts";
+
+@Guard()
+export class GuardComponent implements GuardTarget {
+
+    onGuard(request: Mandarine.Types.RequestContext) {
+        return request != undefined;
+    }
+
+}
+
+export const falseGuard: GuardTargetMethod = (request) => {
+    console.log(request);
+    return false;
+}
+
+@Controller()
+export class MyController {
+    
+    @GET('/hello-world')
+    public handler() {
+        return "Hello world";
+    }
+
+    @GET("/protected")
+    @UseGuards([GuardComponent])
+    public handler2() {
+        return "Protection Passed";
+    }
+
+    @GET("/protected-2")
+    @UseGuards([GuardComponent, falseGuard])
+    public handler3() {
+        return "Protection failed";
+    }
+
+}
+
+@Controller()
+@UseGuards([falseGuard])
+export class MyControllerN2 {
+
+    @GET('/hello-world-2')
+    public handler() {
+        return "Didnt Pass";
+    }
+
+}
+
+@Controller()
+@UseGuards([GuardComponent])
+export class MyControllerN3 {
+
+    @GET('/hello-world-3')
+    public handler() {
+        return "Passed";
+    }
+
+}
+
+
+@Controller()
+@UseGuards([falseGuard, GuardComponent])
+export class MyControllerN4 {
+
+    @GET('/hello-world-4')
+    public handler() {
+        return "Didnt Pass";
+    }
+
+}
+
+new MandarineCore().MVC().run({ port: 7555 });

--- a/tests/integration-tests/guards_test.ts
+++ b/tests/integration-tests/guards_test.ts
@@ -1,0 +1,68 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
+import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+
+export class GuardsTest {
+
+    public MAX_COMPILATION_TIMEOUT_SECONDS = 55;
+
+    constructor() {
+        Orange.setOptions(this, {
+            hooks: {
+                beforeEach: () => CommonUtils.sleep(2)
+            }
+        })
+    }
+
+    @Test({
+        name: "Test Endpoints from `files/guards.ts`",
+        description: "Test all endpoints in file, and verifies that guards are working fine"
+    })
+    public async testGuardsEndpoints() {
+        let cmd = Deno.run({
+            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/guards.ts`],
+            stdout: "null",
+            stderr: "null",
+            stdin: "null"
+        });
+
+        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+
+        let test1 = (await (await fetch("http://localhost:7555/hello-world")).text());
+        let test2 = (await (await fetch("http://localhost:7555/protected")).text());
+
+        let test3Req = await fetch("http://localhost:7555/protected-2");
+        let test3 = await test3Req.text();
+
+
+        let test4Req = await fetch("http://localhost:7555/hello-world-2");
+        let test4 = await test4Req.text();
+
+        let test5 = (await (await fetch("http://localhost:7555/hello-world-3")).text());
+
+        let test6Req = await fetch("http://localhost:7555/hello-world-4");
+        let test6 = await test6Req.text();
+
+        let errorThrown = undefined;
+        try {
+            DenoAsserts.assertEquals(test1, "Hello world");
+            DenoAsserts.assertEquals(test2, "Protection Passed");
+            DenoAsserts.assertEquals(test3Req.status, 401);
+            DenoAsserts.assertEquals(test3, "");
+            DenoAsserts.assertEquals(test4Req.status, 401);
+            DenoAsserts.assertEquals(test4, "");
+            DenoAsserts.assertEquals(test5, "Passed");
+            DenoAsserts.assertEquals(test6Req.status, 401);
+            DenoAsserts.assertEquals(test6, "");
+        } catch(error) {
+            errorThrown = error;
+        }
+        
+        cmd.close();
+        if(errorThrown != undefined) {
+            throw errorThrown;
+        }
+    }
+
+}

--- a/tests/integration-tests/pipe_test.ts
+++ b/tests/integration-tests/pipe_test.ts
@@ -5,7 +5,7 @@ import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } fr
 
 export class PipeTest {
 
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 25;
+    public MAX_COMPILATION_TIMEOUT_SECONDS = 55;
 
     constructor() {
         Orange.setOptions(this, {


### PR DESCRIPTION
-@UseGuards decorator targets a controller or http handler, receives an array that can contains referential type for a mandarine-powered component or a function if no dependency injection is needed.
-@Guard decorator to create a stereotype component with single rsponsability
-Refactors