### PR TITLE
Fix connection management:

### DIFF
--- a/orm-core/connectors/postgreSQLConnector.ts
+++ b/orm-core/connectors/postgreSQLConnector.ts
@@ -64,9 +64,11 @@ export class PostgresConnector implements PostgresConnectorInterface {
 
     public async query(query: string | QueryConfig): Promise<QueryResult> {
       try {
-        let connection = await this.makeConnection();
-        let result: Promise<QueryResult> = connection.query(query);
-        return result;
+        const connection = await this.makeConnection();
+        if(!connection) throw new Error(`Connection could not be made under query ${query}`);
+        const result: QueryResult = await connection.query(query);
+        await connection.release();
+        return Object.assign({}, result);
       }catch(error) {
         this.logger.compiler("Query statement could not be executed", "error", error);
       }

--- a/orm-core/repository/repositoryPostgresProxy.ts
+++ b/orm-core/repository/repositoryPostgresProxy.ts
@@ -23,10 +23,9 @@ export class PostgresRepositoryProxy<T> implements Mandarine.ORM.RepositoryProxy
 
     public async executeQuery(query: any) {
         let dbClient: PostgresConnector = this.getEntityManager().getDatabaseClient();
-        let connection = await (dbClient).makeConnection();
             try{
-                let queryExecution = await dbClient.queryWithConnection(connection, query);
-                let rowsOfObjects = await queryExecution.rowsOfObjects();
+                let queryExecution = await dbClient.query(query);
+                let rowsOfObjects = queryExecution.query.result.rowsOfObjects();
                 if(rowsOfObjects.length == 0) {
                     return null;
                 } else if(rowsOfObjects.length >= 1) {


### PR DESCRIPTION
This PR fixes the bad management for query connections, before it wasn't releasing any connection, now when the query finishes it releases the connection. I've come to realize that Deno is not stable enough in terms of database drivers, so a red flag for databases including mandarine orm.