### PR TITLE
Freezing resource handlers after setting them up in the registry

### DIFF
--- a/main-core/Mandarine.ns.ts
+++ b/main-core/Mandarine.ns.ts
@@ -582,6 +582,7 @@ export namespace Mandarine {
             addResourceHandler(input: ResourceHandler): IResourceHandlerRegistry;
             getResourceHandlers(): Array<ResourceHandler>;
             getNew(): IResourceHandlerRegistry;
+            freezeResourceHandlers(): void;
         }
 
         /**

--- a/main-core/application-context/mandarineApplicationContext.ts
+++ b/main-core/application-context/mandarineApplicationContext.ts
@@ -31,14 +31,6 @@ export class ApplicationContext implements Mandarine.ApplicationContext.IApplica
         ApplicationContext.CONTEXT_METADATA.startupDate = Math.round(+new Date()/1000);
     }
 
-    public changeResourceHandlers(newResourceHandlerRegistry: Mandarine.MandarineCore.IResourceHandlerRegistry): void {
-        if(newResourceHandlerRegistry.getResourceHandlers().length > 0) {
-            let mandarineGlobal: Mandarine.Global.MandarineGlobalInterface  = Mandarine.Global.getMandarineGlobal();
-            mandarineGlobal.mandarineResourceHandlerRegistry = newResourceHandlerRegistry;
-            mandarineGlobal.mandarineResourceHandlerRegistry.overriden = true;
-        } 
-    }
-
     public static getInstance(): Mandarine.ApplicationContext.IApplicationContext {
         if(ApplicationContext.applicationContextSingleton == (null || undefined)) { 
             ApplicationContext.applicationContextSingleton = new ApplicationContext(); 

--- a/main-core/proxys/nativeComponentsOverrideProxy.ts
+++ b/main-core/proxys/nativeComponentsOverrideProxy.ts
@@ -37,6 +37,7 @@ export namespace NativeComponentsOverrideProxy {
                 let mandarineGlobal: Mandarine.Global.MandarineGlobalInterface  = Mandarine.Global.getMandarineGlobal();
                 mandarineGlobal.mandarineResourceHandlerRegistry = newResourceHandlerRegistry;
                 mandarineGlobal.mandarineResourceHandlerRegistry.overriden = true;
+                mandarineGlobal.mandarineResourceHandlerRegistry.freezeResourceHandlers();
             } 
         }
     }

--- a/main-core/utils/mandarineUtils.ts
+++ b/main-core/utils/mandarineUtils.ts
@@ -45,7 +45,7 @@ export class MandarineUtils {
         }
     }
 
-    public static absoluteZeroFreeze(object: Object) {
+    public static absoluteZeroFreeze<T = any>(object: Object): Readonly<T> {
         const objectKeys: Array<string> = Object.keys(object);
         let objectToReturn: { [prop: string]: any } = Object.assign({}, object);
 
@@ -58,6 +58,6 @@ export class MandarineUtils {
             }
         });
 
-        return Object.freeze(objectToReturn);
+        return <T> Object.freeze(objectToReturn);
     }
 }

--- a/mvc-framework/core/internal/components/resource-handler-registry/resourceHandlerRegistry.ts
+++ b/mvc-framework/core/internal/components/resource-handler-registry/resourceHandlerRegistry.ts
@@ -2,6 +2,7 @@
 
 import type { Mandarine } from "../../../../../main-core/Mandarine.ns.ts";
 import { CommonUtils } from "../../../../../main-core/utils/commonUtils.ts";
+import { MandarineUtils } from "../../../../../main-core/utils/mandarineUtils.ts";
 import type { ResourceHandler } from "./resourceHandler.ts";
 
 /**
@@ -26,6 +27,14 @@ export class ResourceHandlerRegistry implements Mandarine.MandarineCore.IResourc
 
     public getNew(): Mandarine.MandarineCore.IResourceHandlerRegistry {
         return new ResourceHandlerRegistry();
+    }
+
+    public freezeResourceHandlers(): void {
+        this.resourceHandlers.forEach((item, index) => {
+            const newItem = MandarineUtils.absoluteZeroFreeze<ResourceHandler>(item);
+            this.resourceHandlers[index] = newItem;
+        })
+        this.resourceHandlers = <any> Object.freeze(this.resourceHandlers);
     }
 
 }

--- a/tests/unit-tests/resourceHandler_test.ts
+++ b/tests/unit-tests/resourceHandler_test.ts
@@ -22,7 +22,7 @@ export class ResourceHandlerTest {
 
     @Test({
         name: "Test Resource Handlers",
-        description: "Test the creation of multiple resource handlers"
+        description: "Test the creation of multiple resource handlers & freezing"
     })
     public createResourceHandlers() {
         let mandarineResolver = new MandarineResourceResolver();
@@ -54,6 +54,13 @@ export class ResourceHandlerTest {
             }
         ]);
         DenoAsserts.assert(resourceHandlers[0].resourceResolver instanceof MandarineResourceResolver);
+
+        const firstResourceHandler = Mandarine.Global.getResourceHandlerRegistry().getResourceHandlers()[0];
+        DenoAsserts.assertThrows(() => {
+            if(firstResourceHandler.resourceHandlerPath != undefined && Array.isArray(firstResourceHandler.resourceHandlerPath)) {
+                firstResourceHandler.resourceHandlerPath.push(new RegExp("whatever"));
+            }
+        }, TypeError, "object is not extensible")
     }
 
 }


### PR DESCRIPTION
With this feature, now it freezes the resource handler items after being set up, this is to avoid changing resource handlers at runtime which can highly affect the way a web serves static content or others. This is a security issue.