### PR TITLE
Support open api

### DIFF
--- a/main-core/Mandarine.ns.ts
+++ b/main-core/Mandarine.ns.ts
@@ -565,7 +565,7 @@ export namespace Mandarine {
             getComponents(): ComponentRegistryContext[];
             getControllers(): ComponentRegistryContext[];
             getComponentsByComponentType(componentType: Mandarine.MandarineCore.ComponentTypes): Mandarine.MandarineCore.ComponentRegistryContext[];
-            getComponentByHandlerType(classType: any): ComponentRegistryContext | undefined;
+            getComponentByHandlerType(classType: any, requiredType?: Mandarine.MandarineCore.ComponentTypes): ComponentRegistryContext | undefined;
             resolveDependencies(): void;
             getRepositoryByHandlerType(classType: any): Mandarine.MandarineCore.ComponentRegistryContext | undefined;
             connectRepositoriesToProxy(): void;

--- a/main-core/components-registry/componentRegistry.ts
+++ b/main-core/components-registry/componentRegistry.ts
@@ -136,7 +136,7 @@ export class ComponentsRegistry implements Mandarine.MandarineCore.IComponentsRe
         return this.getComponentsByComponentType(Mandarine.MandarineCore.ComponentTypes.REPOSITORY);
     }
 
-    public getComponentByHandlerType(classType: any): Mandarine.MandarineCore.ComponentRegistryContext | undefined {
+    public getComponentByHandlerType(classType: any, requiredType?: Mandarine.MandarineCore.ComponentTypes): Mandarine.MandarineCore.ComponentRegistryContext | undefined {
         try {
             return this.getComponents().find((component: Mandarine.MandarineCore.ComponentRegistryContext) => {
                 let instance = undefined;
@@ -150,7 +150,7 @@ export class ComponentsRegistry implements Mandarine.MandarineCore.IComponentsRe
                 // When this method is used, it should be used after initialization of dependencies
                 if(!ReflectUtils.checkClassInitialized(instance)) instance = new instance();
 
-                return instance instanceof classType;
+                return instance instanceof classType && ((requiredType) ? (component.componentType == requiredType) : true);
             });
         } catch {
             return undefined;

--- a/main-core/dependency-injection/di.ns.ts
+++ b/main-core/dependency-injection/di.ns.ts
@@ -42,6 +42,7 @@ export namespace DI {
         parameterMethodName: string;
         parameterObjectToInject?: any;
         parameterConfiguration?: any;
+        parameterOriginalMetadataType?: any;
         propertyName: string;
         className: string;
     }

--- a/main-core/dependency-injection/di.util.ts
+++ b/main-core/dependency-injection/di.util.ts
@@ -22,7 +22,6 @@ export class DependencyInjectionUtil {
 
         if(isMethod) {
             let methodArgumentTypes = Reflect.getMetadata("design:paramtypes", target, propertyName);
-
             let methodParams: Array<string> = ReflectUtils.getParamNames(target[propertyName]);
             let parameterName: string = methodParams[parameterIndex];
 
@@ -38,6 +37,7 @@ export class DependencyInjectionUtil {
                 parameterIndex: parameterIndex,
                 parameterMethodName: propertyName,
                 parameterObjectToInject: (injectionType == DI.InjectionTypes.INJECTABLE_OBJECT) ? methodArgumentTypes[parameterIndex] : undefined,
+                parameterOriginalMetadataType: methodArgumentTypes[parameterIndex]?.name,
                 propertyName: <string> <unknown> undefined,
                 className: parentClassName,
                 parameterConfiguration: parameterConfiguration

--- a/main-core/utils/commonUtils.ts
+++ b/main-core/utils/commonUtils.ts
@@ -4,6 +4,8 @@ import { v4 } from "https://deno.land/std@0.84.0/uuid/mod.ts";
 import { MandarineException } from "../exceptions/mandarineException.ts";
 import type { Mandarine } from "../Mandarine.ns.ts";
 import { Leaf } from "../../deps.ts";
+import { IndependentUtils } from "./independentUtils.ts";
+
 export class CommonUtils {
     public static generateUUID(): string {
         return v4.generate();
@@ -67,7 +69,7 @@ export class CommonUtils {
     }
 
     public static isObject(o: any): boolean {
-        return o instanceof Object && o.constructor === Object;
+        return IndependentUtils.isObject(o);
     }
 
     public static isNumeric(num: any) {

--- a/main-core/utils/httpUtils.ts
+++ b/main-core/utils/httpUtils.ts
@@ -205,5 +205,15 @@ export class HttpUtils {
         
         context.response.headers.set('Content-Type', contentType);
     }
+
+    public static getFakeRequestContext() {
+        return {
+            request: {
+                url: ""
+            },
+            params: [],
+            cookies: []
+        }
+    }
     
 }

--- a/main-core/utils/independentUtils.ts
+++ b/main-core/utils/independentUtils.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 export class IndependentUtils {
     public static isVersionValidSemantic(v: string = ""): boolean {
         let match = /(\d+)\.(\d+).(\d+)/.exec(v);

--- a/main-core/utils/independentUtils.ts
+++ b/main-core/utils/independentUtils.ts
@@ -1,0 +1,28 @@
+export class IndependentUtils {
+    public static isVersionValidSemantic(v: string = ""): boolean {
+        let match = /(\d+)\.(\d+).(\d+)/.exec(v);
+        if (match) {
+          let major = parseInt(match[1], 10);
+          if (major >= 3) {
+            return true;
+          }
+        }
+        return false;
+    }
+
+    public static moveToFront<T = any>(array: Array<T>, property: any, expectedValue: any): Array<T> {
+      const newArray = [...array];
+      newArray.forEach((item: T, i) => {
+        // @ts-ignore
+        if(item[property] === expectedValue) {
+          newArray.splice(i, 1);
+          newArray.unshift(item);
+        }
+      });
+      return newArray;
+    }
+
+    public static isObject(o: any): boolean {
+      return o instanceof Object && o.constructor === Object;
+    }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -55,3 +55,8 @@ export { UseGuards } from "./mvc-framework/core/decorators/stereotypes/controlle
 export { parameterDecoratorFactory } from "./mvc-framework/core/decorators/custom-decorators/decoratorsFactory.ts";
 
 export { Authenticator } from "./main-core/mandarine-native/security/authenticatorDefault.ts";
+
+/*
+OpenAPI
+*/
+export { ApiOperation, ApiParameter, ApiResponse, ApiExternalDoc, ApiTag, ApiServer, OpenAPIBuilder } from "./mvc-framework/openapi/openApiMod.ts";

--- a/mvc-framework/mandarineMVC.ts
+++ b/mvc-framework/mandarineMVC.ts
@@ -8,6 +8,9 @@ import { MandarineMvcFrameworkStarter } from "./engine/mandarineMvcFrameworkStar
 import { handleBuiltinAuth } from "./core/middlewares/authMiddleware.ts";
 import { HttpUtils } from "../main-core/utils/httpUtils.ts";
 import { ExceptionHandler } from "./core/middlewares/exceptionHandler.ts";
+import { OpenAPIBuilder } from "./openapi/openApiBuilder.ts";
+import { openAPIApplicationBuilder } from "./openapi/openapi-global.ts";
+import { mandarineOpenAPIInitializer } from "./openapi/mandarineOpenAPIInitializer.ts";
 
 /**
  * This class is the bridge between the HTTP server & the Mandarine Compiler.
@@ -65,12 +68,18 @@ export class MandarineMVC {
     }
   }
 
+  public openAPI(documentBuilder: (document: OpenAPIBuilder) => OpenAPIBuilder): MandarineMVC {
+    documentBuilder(openAPIApplicationBuilder);
+    return this;
+  }
+
   private initializeMVCApplication(): Application {
     let mandarineConfiguration: Mandarine.Properties = Mandarine.Global.getMandarineConfiguration();
 
     let starter: MandarineMvcFrameworkStarter = new MandarineMvcFrameworkStarter((engine: MandarineMvcFrameworkStarter) => {
         engine.intializeControllersRoutes();
         engine.initializeEssentials();
+        mandarineOpenAPIInitializer();
       }
     );
 

--- a/mvc-framework/mandarineMVC.ts
+++ b/mvc-framework/mandarineMVC.ts
@@ -11,6 +11,7 @@ import { ExceptionHandler } from "./core/middlewares/exceptionHandler.ts";
 import { OpenAPIBuilder } from "./openapi/openApiBuilder.ts";
 import { openAPIApplicationBuilder } from "./openapi/openapi-global.ts";
 import { mandarineOpenAPIInitializer } from "./openapi/mandarineOpenAPIInitializer.ts";
+import { MandarineException } from "../main-core/exceptions/mandarineException.ts";
 
 /**
  * This class is the bridge between the HTTP server & the Mandarine Compiler.
@@ -70,6 +71,11 @@ export class MandarineMVC {
 
   public openAPI(documentBuilder: (document: OpenAPIBuilder) => OpenAPIBuilder): MandarineMVC {
     documentBuilder(openAPIApplicationBuilder);
+    return this;
+  }
+
+  public saveOpenAPI(path: string | URL): MandarineMVC {
+    openAPIApplicationBuilder.setInternalSaveFile(path);
     return this;
   }
 

--- a/mvc-framework/openapi/decorators/apiExternalDoc.ts
+++ b/mvc-framework/openapi/decorators/apiExternalDoc.ts
@@ -1,0 +1,12 @@
+import { addOpenAPILoaderInfo } from "../openapi-global.ts";
+import { OpenAPIExternalDocs } from "../openapi-spec.ts";
+
+export const ApiExternalDoc = (apiExternalDoc: OpenAPIExternalDocs) => {
+    return (target: any, methodName: string) => {
+        addOpenAPILoaderInfo(target, {
+            type: "ApiExternalDoc",
+            methodName: methodName,
+            data: apiExternalDoc
+        })
+    }
+}

--- a/mvc-framework/openapi/decorators/apiExternalDoc.ts
+++ b/mvc-framework/openapi/decorators/apiExternalDoc.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { addOpenAPILoaderInfo } from "../openapi-global.ts";
 import { OpenAPIExternalDocs } from "../openapi-spec.ts";
 

--- a/mvc-framework/openapi/decorators/apiResponse.ts
+++ b/mvc-framework/openapi/decorators/apiResponse.ts
@@ -1,0 +1,12 @@
+import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
+import { OpenAPIResponse } from "../openapi-spec.ts";
+
+export const ApiResponse = (apiResponse: OpenAPIResponse) => {
+    return (target: any, methodName: string) => {
+        addOpenAPILoaderInfo(target, {
+            type: "ApiResponse",
+            methodName: methodName,
+            data: apiResponse
+        })
+    }
+}

--- a/mvc-framework/openapi/decorators/apiResponse.ts
+++ b/mvc-framework/openapi/decorators/apiResponse.ts
@@ -1,8 +1,13 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
 import { OpenAPIResponse } from "../openapi-spec.ts";
 
 export const ApiResponse = (apiResponse: OpenAPIResponse) => {
-    return (target: any, methodName: string) => {
+    return (target: any, methodName?: string) => {
+
+        if(!methodName && !apiResponse.responseCode) throw new Error("A response code (response name) must be assigned when using @ApiResponse in a class");
+        
         addOpenAPILoaderInfo(target, {
             type: "ApiResponse",
             methodName: methodName,

--- a/mvc-framework/openapi/decorators/apiServer.ts
+++ b/mvc-framework/openapi/decorators/apiServer.ts
@@ -1,0 +1,12 @@
+import { addOpenAPILoaderInfo } from "../openapi-global.ts";
+import { OpenAPIServer } from "../openapi-spec.ts";
+
+export const ApiServer = (apiServer: OpenAPIServer) => {
+    return (target: any, methodName?: string) => {
+        addOpenAPILoaderInfo(target, {
+            type: "ApiServer",
+            methodName: methodName,
+            data: apiServer
+        })
+    }
+}

--- a/mvc-framework/openapi/decorators/apiServer.ts
+++ b/mvc-framework/openapi/decorators/apiServer.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { addOpenAPILoaderInfo } from "../openapi-global.ts";
 import { OpenAPIServer } from "../openapi-spec.ts";
 

--- a/mvc-framework/openapi/decorators/apiTag.ts
+++ b/mvc-framework/openapi/decorators/apiTag.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { IndependentUtils } from "../../../main-core/utils/independentUtils.ts";
 import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
 import { OpenAPITagObject } from "../openapi-spec.ts";

--- a/mvc-framework/openapi/decorators/apiTag.ts
+++ b/mvc-framework/openapi/decorators/apiTag.ts
@@ -1,0 +1,32 @@
+import { IndependentUtils } from "../../../main-core/utils/independentUtils.ts";
+import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
+import { OpenAPITagObject } from "../openapi-spec.ts";
+
+export const ApiTag = (tag: OpenAPITagObject | Array<OpenAPITagObject | string> | string) => {
+    return (target: any, methodName: string, propertyDesciptor: PropertyDescriptor) => {
+
+        const consumer: Array<OpenAPITagObject> = [];
+        
+        if(typeof tag === "string") {
+            consumer.push({ name: tag });
+        }  else {
+            if(Array.isArray(tag)) {
+                tag.forEach((item) => {
+                    if (typeof item === "string") {
+                        consumer.push({ name: item });
+                    } else if (IndependentUtils.isObject(item)) {
+                        consumer.push(item);
+                    }
+                });
+            } else if(IndependentUtils.isObject(tag)) {
+                consumer.push(tag);
+            }
+        }
+
+        addOpenAPILoaderInfo(target, {
+            type: "ApiTag",
+            methodName: methodName,
+            data: consumer
+        })
+    }
+}

--- a/mvc-framework/openapi/decorators/operation.ts
+++ b/mvc-framework/openapi/decorators/operation.ts
@@ -1,0 +1,15 @@
+import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
+import { OpenAPIOperationObject } from "../openapi-spec.ts";
+
+export const ApiOperation = (operation: OpenAPIOperationObject) => {
+    return (target: any, methodName: string, propertyDesciptor: PropertyDescriptor) => {
+
+        if(!operation.operationId) operation.operationId = methodName;
+
+        addOpenAPILoaderInfo(target, {
+            type: "ApiOperation",
+            methodName: methodName,
+            data: operation
+        })
+    }
+}

--- a/mvc-framework/openapi/decorators/operation.ts
+++ b/mvc-framework/openapi/decorators/operation.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
 import { OpenAPIOperationObject } from "../openapi-spec.ts";
 

--- a/mvc-framework/openapi/decorators/parameter.ts
+++ b/mvc-framework/openapi/decorators/parameter.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
 import { OpenAPIParameter } from "../openapi-spec.ts";
 

--- a/mvc-framework/openapi/decorators/parameter.ts
+++ b/mvc-framework/openapi/decorators/parameter.ts
@@ -1,0 +1,13 @@
+import { addOpenAPILoaderInfo, openAPIApplicationBuilder } from "../openapi-global.ts";
+import { OpenAPIParameter } from "../openapi-spec.ts";
+
+export const ApiParameter = (parameter: OpenAPIParameter) => {
+    return (target: any, methodName: string, parameterIndex: number) => {
+        addOpenAPILoaderInfo(target, {
+            type: "ApiParameter",
+            methodName: methodName,
+            parameterIndex: parameterIndex,
+            data: parameter
+        })
+    }
+}

--- a/mvc-framework/openapi/mandarineOpenAPIInitializer.ts
+++ b/mvc-framework/openapi/mandarineOpenAPIInitializer.ts
@@ -1,0 +1,131 @@
+import { ApplicationContext } from "../../main-core/application-context/mandarineApplicationContext.ts"
+import { DI } from "../../main-core/dependency-injection/di.ns.ts";
+import { DependencyInjectionUtil } from "../../main-core/dependency-injection/di.util.ts";
+import { Mandarine } from "../../main-core/Mandarine.ns.ts";
+import { Reflect } from "../../main-core/reflectMetadata.ts";
+import { HttpUtils } from "../../main-core/utils/httpUtils.ts";
+import { ReflectUtils } from "../../main-core/utils/reflectUtils.ts";
+import { ControllerComponent } from "../core/internal/components/routing/controllerContext.ts";
+import { openAPIApplicationBuilder, OpenAPILoaderData, openAPILoaderInformation } from "./openapi-global.ts";
+import { OpenAPIExternalDocs, OpenAPIOperationObject, OpenAPIParameter, OpenAPIResponse, OpenAPIServer, OpenAPITagObject } from "./openapi-spec.ts";
+
+export const mandarineOpenAPIInitializer = () => {
+    ApplicationContext.getInstance().getComponentsRegistry().getControllers().forEach((componentFromRegistry) => {
+        if (componentFromRegistry) {
+            const controller: ControllerComponent = componentFromRegistry.componentInstance;
+            const component = controller.getClassHandlerType().prototype;
+            const openApiComponent = openAPILoaderInformation.get(component);
+            const operations: Array<OpenAPILoaderData> = openApiComponent?.filter((loaderData) => loaderData.type == "ApiOperation") || [];
+
+            operations.forEach((loaderData: OpenAPILoaderData) => {
+                const data: OpenAPIOperationObject = loaderData.data;
+                const methodName: string = <string> loaderData.methodName;
+                const routeAction = controller.getRoutingAction(methodName);
+                let methodParams: Array<string> = ReflectUtils.getParamNames(component[methodName]);
+
+                if(routeAction) {
+                    const fullRoute = controller.getFullRoute(routeAction.route);
+                    const httpMethod: string = Mandarine.MandarineMVC.HttpMethods[routeAction.actionType].toLowerCase();
+                    
+                    const registeredResponses: Array<OpenAPILoaderData> = openApiComponent?.filter((loaderData) => loaderData.type == "ApiResponse" && loaderData.methodName == methodName) || [];
+                    const registeredParameters: Array<OpenAPILoaderData> = openApiComponent?.filter((loaderData) => loaderData.type == "ApiParameter" && loaderData.methodName == methodName) || [];
+                    const registeredServers: Array<OpenAPILoaderData> = openApiComponent?.filter((loaderData) => loaderData.type == "ApiServer" && loaderData.methodName == methodName) || [];
+                    const registeredExternalDoc: OpenAPILoaderData | undefined = openApiComponent?.find((loaderData) => loaderData.type == "ApiExternalDoc" && loaderData.methodName == methodName);
+                    const registeredTags: Array<OpenAPILoaderData> = openApiComponent?.filter((loaderData) => loaderData.type == "ApiTag" && loaderData.methodName == methodName) || [];
+
+                    // @ts-ignore
+                    const { metadataValues } = DependencyInjectionUtil.getDIHandlerContext(component, methodName, HttpUtils.getFakeRequestContext() as any)
+                    const metadataValuesTyped: Array<DI.InjectionMetadataContext> = metadataValues || [];     
+
+                    registeredResponses.forEach((responseLoaderData) => {
+                        let responseData: OpenAPIResponse = responseLoaderData.data;
+
+                        if(!responseData.responseCode) {
+                            data.responses.default = responseData;
+                        } else {
+                            const responseCode = responseData.responseCode;
+                            delete responseData.responseCode;
+                            data.responses[responseCode] = responseData;
+                        }
+
+                    });               
+
+                    registeredParameters.forEach((parameterLoaderData) => {
+                        let parameterData: OpenAPIParameter = parameterLoaderData.data;
+                        let parameterIndex: number | undefined = parameterLoaderData.parameterIndex;
+                        let parameterName: string = methodParams[parameterIndex || 0];
+                        let parameterMetadata: DI.InjectionMetadataContext | undefined = metadataValuesTyped.find((item) => item.parameterIndex == parameterIndex);
+
+                        if(parameterMetadata) {
+                            switch(parameterMetadata.injectionType) {
+                                case DI.InjectionTypes.QUERY_PARAM:
+                                    parameterData.in = "query";
+                                break;
+                                case DI.InjectionTypes.COOKIE_PARAM:
+                                    parameterData.in = "cookie";
+                                break;
+                                case DI.InjectionTypes.ROUTE_PARAM:
+                                    parameterData.in = "path";
+                                break;
+                            }
+                            const parameterMetadataOriginalType = parameterMetadata.parameterOriginalMetadataType?.toLowerCase();
+                            if(parameterMetadata.parameterOriginalMetadataType) {
+                                parameterData.schema = {
+                                    type: parameterMetadataOriginalType
+                                }
+                            }
+                        }
+
+                        if(!parameterData.required) {
+                            parameterData.required = false;
+                        }
+
+
+                        // @ts-ignore
+                        parameterData["name"] = parameterName;
+
+                        if(!data.parameters) {
+                            data.parameters = [];
+                        }
+
+                        data.parameters?.push(parameterData)
+                    });
+
+                    registeredServers.forEach((serverLoaderData) => {
+                        let serverData: OpenAPIServer = serverLoaderData.data;
+                        data.servers?.push(serverData);
+                    });
+
+                    registeredTags.forEach((item) => {
+                        let tagData: Array<OpenAPITagObject> = item.data;
+                        let stringTags: Array<string> = tagData.map((item) => item.name);
+                        if(!Array.isArray(data.tags)) {
+                            data.tags = stringTags;
+                        } else {
+                            stringTags.forEach((tag) => data.tags?.push(tag));
+                        }
+
+                        tagData.forEach((item) => {
+                            const keys = Object.keys(item);
+                            // It's more than just a `name`
+                            if (keys.length > 1) {
+                                openAPIApplicationBuilder.setTag(item);
+                            }
+                        })
+                    })
+
+                    if(registeredExternalDoc) {
+                        const externalDocData: OpenAPIExternalDocs = registeredExternalDoc.data;
+                        data.externalDocs = externalDocData;
+                    }
+
+                    openAPIApplicationBuilder.setPath(fullRoute, {
+                        [httpMethod]: data
+                    });
+                }
+
+
+            })
+        }
+    })
+}

--- a/mvc-framework/openapi/openApiBuilder.ts
+++ b/mvc-framework/openapi/openApiBuilder.ts
@@ -1,0 +1,239 @@
+import { OpenAPIContact, OpenAPIExampleObject, OpenAPIExternalDocumentationObject, OpenAPIHeaderObject, OpenAPIInfo, OpenAPILicense, OpenAPILinkObject, OpenAPIParameter, OpenAPIPath, OpenAPIRequestBody, OpenAPIResponse, OpenAPISchemaObject, OpenAPISecuritySchemeObject, OpenAPIServer, OpenAPISpec, OpenAPITagObject, OPEN_API_VERSION, REF_OBJECT } from "./openapi-spec.ts";
+import { IndependentUtils } from "../../main-core/utils/independentUtils.ts";
+import  * as YAML from "https://deno.land/std@0.85.0/encoding/yaml.ts";
+
+export class OpenAPIBuilder {
+    private document: OpenAPISpec;
+
+    constructor(docoument?: OpenAPISpec) {
+        this.document = docoument || {
+            openapi: OPEN_API_VERSION,
+            info: {
+                title: "App",
+                version: "1.0.0"
+            },
+            servers: new Array<OpenAPIServer>(),
+            paths: {},
+            components: {
+                schemas: {},
+                responses: {},
+                parameters: {},
+                examples: {},
+                requestBodies: {},
+                headers: {},
+                securitySchemes: {},
+                links: {},
+                callbacks: {},
+            },
+            tags: new Array<OpenAPITagObject>()
+        };
+    }
+
+    /**
+     * Gets current Open API document as a javascript object
+     */
+    public getSpec(): OpenAPISpec {
+        return this.document;
+    }
+
+    /**
+     * Gets current Open API Document as a JSON string
+     */
+    public toJSON(replacer?: (this: any, key: string, value: any) => any, space?: string | number): string {
+        return JSON.stringify(this.document, replacer, space);
+    }
+
+    /**
+     * Gets current Open API Document as a YAML string
+     */
+    public toYAML(): string {
+        return YAML.stringify( <any> this.document);
+    }
+
+    /**
+     * Sets a new Open API version to the document
+     */
+    public setOpenAPIVersion(version: string): OpenAPIBuilder {
+        if(IndependentUtils.isVersionValidSemantic(version)) {
+            this.document.openapi = version;
+            return this;
+        } else {
+            throw new Error("Invalid OpenAPI version. Convention needs to follow semantic versioning.");
+        }
+    }
+
+    /**
+     * Sets the property info in the Open API Document
+     */
+    public setInfo(info: OpenAPIInfo): OpenAPIBuilder {
+        this.document.info = info;
+        return this;
+    }
+
+    /**
+     * Sets the property `contact` inside the `info` object in the Open API Document
+     */    
+    public setContact(contact: OpenAPIContact): OpenAPIBuilder {
+        this.document.info.contact = contact;
+        return this;
+    }
+
+    /**
+     * Sets the property `license` inside the `info` object in the Open API Document
+     */    
+    public setLicense(license: OpenAPILicense): OpenAPIBuilder {
+        this.document.info.license = license;
+        return this;
+    }
+
+    /**
+     * Sets the property `title` inside the `info` object in the Open API Document
+     */     
+    public setTitle(title: string): OpenAPIBuilder {
+        this.document.info.title = title;
+        return this;
+    }
+
+    /**
+     * Sets the property `description` inside the `info` object in the Open API Document
+     */     
+    public setDescription(description: string): OpenAPIBuilder {
+        this.document.info.description = description;
+        return this;
+    }
+
+    /**
+     * Sets the property `termsOfService` inside the `info` object in the Open API Document
+     */
+    public setTermsOfService(termsOfService: string): OpenAPIBuilder {
+        this.document.info.termsOfService = termsOfService;
+        return this;
+    }
+
+    /**
+     * Sets the property `version` inside the `info` object in the Open API Document
+     */
+    public setVersion(version: string): OpenAPIBuilder {
+        this.document.info.version = version;
+        return this;
+    }
+
+    /**
+     * Adds a new path to the `paths` property in the Open API Document
+     */
+    public setPath(path: string, pathItem: OpenAPIPath): OpenAPIBuilder {
+        if (this.document.paths[path]) {
+          this.document.paths[path] = { ...this.document.paths[path], ...pathItem };
+        } else {
+          this.document.paths[path] = pathItem;
+        }
+        return this;
+    }
+
+    /**
+     * Adds a new schema inside the components object in the Open API Document
+     */
+    public setSchema(name: string, schema: OpenAPISchemaObject | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.schemas[name] = schema;
+        return this;
+    }
+
+    /**
+     * Adds a new response inside the components object in the Open API Document
+     */
+    public setResponse(name: string, response: OpenAPIResponse| REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.responses[name] = response;
+        return this;
+    }
+
+    /**
+     * Adds a new parameter inside the components object in the Open API Document
+     */    
+    public setParameter(name: string, parameter: OpenAPIParameter | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.parameters[name] = parameter;
+        return this;
+    }
+
+    /**
+     * Adds a new example inside the components object in the Open API Document
+     */
+    public setExample(name: string, example: OpenAPIExampleObject | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.examples[name] = example;
+        return this;
+      }
+
+    /**
+     * Adds a new request body inside the components object in the Open API Document
+     */
+    public setRequestBody(name: string, reqBody: OpenAPIRequestBody | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.requestBodies[name] = reqBody;
+        return this;
+    }
+
+    /**
+     * Adds a new header inside the components object in the Open API Document
+     */
+    public setHeader(name: string, header: OpenAPIHeaderObject | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.headers[name] = header;
+        return this;
+    }
+
+    /**
+     * Adds a new security schema inside the components object in the Open API Document
+     */
+    public setSecurityScheme(name: string, secScheme: OpenAPISecuritySchemeObject | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.securitySchemes[name] = secScheme;
+        return this;
+    }
+
+    /**
+     * Adds a new link inside the components object in the Open API Document
+     */
+    public setLink(name: string, link: OpenAPILinkObject | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.links[name] = link;
+        return this;
+    }
+
+    /**
+     * Adds a new callback inside the components object in the Open API Document
+     */
+    public setCallback(name: string, callback: OpenAPIPath | REF_OBJECT): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.components.callbacks[name] = callback;
+        return this;
+    }
+
+    /**
+     * Adds a new server in the Open API Document
+     */
+    public setServer(server: OpenAPIServer): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.servers.push(server);
+        return this;
+    }
+
+    /**
+     * Adds a new tag in the Open API Document
+     */
+    public setTag(tag: OpenAPITagObject): OpenAPIBuilder {
+        // @ts-ignore
+        this.document.tags.push(tag);
+        return this;
+    }
+
+    /**
+     * Adds a new external documentation in the Open API Document
+     */
+    public setExternalDocs(extDoc: OpenAPIExternalDocumentationObject): OpenAPIBuilder {
+        this.document.externalDocs = extDoc;
+        return this;
+    }
+}

--- a/mvc-framework/openapi/openApiBuilder.ts
+++ b/mvc-framework/openapi/openApiBuilder.ts
@@ -1,9 +1,12 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { OpenAPIContact, OpenAPIExampleObject, OpenAPIExternalDocumentationObject, OpenAPIHeaderObject, OpenAPIInfo, OpenAPILicense, OpenAPILinkObject, OpenAPIParameter, OpenAPIPath, OpenAPIRequestBody, OpenAPIResponse, OpenAPISchemaObject, OpenAPISecuritySchemeObject, OpenAPIServer, OpenAPISpec, OpenAPITagObject, OPEN_API_VERSION, REF_OBJECT } from "./openapi-spec.ts";
 import { IndependentUtils } from "../../main-core/utils/independentUtils.ts";
 import  * as YAML from "https://deno.land/std@0.85.0/encoding/yaml.ts";
 
 export class OpenAPIBuilder {
     private document: OpenAPISpec;
+    private saveFilePath: string | URL | undefined  = undefined;
 
     constructor(docoument?: OpenAPISpec) {
         this.document = docoument || {
@@ -236,4 +239,21 @@ export class OpenAPIBuilder {
         this.document.externalDocs = extDoc;
         return this;
     }
+
+    /**
+     * Set file to be saved when document is complete.
+     * This method is only used internally by Mandarine
+     */
+    public setInternalSaveFile(path: string | URL) {
+        this.saveFilePath = path;
+    }
+
+    /**
+     * Gets the file to be saved when document is complete.
+     * This method is only used internally by Mandarine
+     */
+    public getInternalSaveFile(): string | URL | undefined {
+        return this.saveFilePath;
+    }
+
 }

--- a/mvc-framework/openapi/openApiMod.ts
+++ b/mvc-framework/openapi/openApiMod.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 export { ApiExternalDoc } from "./decorators/apiExternalDoc.ts";
 export { ApiResponse } from "./decorators/apiResponse.ts";
 export { ApiServer } from "./decorators/apiServer.ts";

--- a/mvc-framework/openapi/openApiMod.ts
+++ b/mvc-framework/openapi/openApiMod.ts
@@ -1,0 +1,7 @@
+export { ApiExternalDoc } from "./decorators/apiExternalDoc.ts";
+export { ApiResponse } from "./decorators/apiResponse.ts";
+export { ApiServer } from "./decorators/apiServer.ts";
+export { ApiTag } from "./decorators/apiTag.ts";
+export { ApiOperation } from "./decorators/operation.ts";
+export { ApiParameter } from "./decorators/parameter.ts";
+export { OpenAPIBuilder } from "./openApiBuilder.ts";

--- a/mvc-framework/openapi/openapi-global.ts
+++ b/mvc-framework/openapi/openapi-global.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { OpenAPIBuilder } from "./openApiBuilder.ts";
 
 export interface OpenAPILoaderData {

--- a/mvc-framework/openapi/openapi-global.ts
+++ b/mvc-framework/openapi/openapi-global.ts
@@ -1,0 +1,20 @@
+import { OpenAPIBuilder } from "./openApiBuilder.ts";
+
+export interface OpenAPILoaderData {
+    type: "ApiOperation" | "ApiParameter" | "ApiResponse" | "ApiServer" | "ApiExternalDoc" | "ApiTag",
+    methodName?: string,
+    parameterIndex?: number,
+    data: any
+}
+
+export const openAPILoaderInformation: Map<any, Array<OpenAPILoaderData>> = new Map<any, Array<OpenAPILoaderData>>();
+
+export const addOpenAPILoaderInfo = (component: any, data: OpenAPILoaderData) => {
+    if(openAPILoaderInformation.has(component)) {
+        openAPILoaderInformation.get(component)?.push(data);
+    } else {
+        openAPILoaderInformation.set(component, [data]);
+    }
+}
+
+export let openAPIApplicationBuilder = new OpenAPIBuilder();

--- a/mvc-framework/openapi/openapi-spec.ts
+++ b/mvc-framework/openapi/openapi-spec.ts
@@ -1,3 +1,4 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 export const OPEN_API_VERSION = "3.0.3";
 export type REF_OBJECT = { $ref: string };
@@ -187,7 +188,7 @@ export interface OpenAPIContent {
   }
 export interface OpenAPIResponse {
     description: string;
-    responseCode?: number;
+    responseCode?: string | number;
     headers?: {
         [prop: string]: OpenAPIHeaderObject | REF_OBJECT
     },

--- a/mvc-framework/openapi/openapi-spec.ts
+++ b/mvc-framework/openapi/openapi-spec.ts
@@ -1,0 +1,317 @@
+
+export const OPEN_API_VERSION = "3.0.3";
+export type REF_OBJECT = { $ref: string };
+export type WithAny = { [prop: string]: any }
+
+export type OpenAPIParameterStyle =
+  | "matrix"
+  | "label"
+  | "form"
+  | "simple"
+  | "spaceDelimited"
+  | "pipeDelimited"
+  | "deepObject";
+
+export type OpenAPISecuritySchemeType = "apiKey" | "http" | "oauth2" | "openIdConnect";
+
+export interface OpenAPIDiscriminatorObject {
+    propertyName: string;
+    mapping?: { [key: string]: string };
+}
+export interface OpenAPIXmlObject extends WithAny {
+    name?: string;
+    namespace?: string;
+    prefix?: string;
+    attribute?: boolean;
+    wrapped?: boolean;
+}
+
+export interface OpenAPIExternalDocumentationObject extends WithAny {
+    description?: string;
+    url: string;
+}
+
+export interface OpenAPIExamplesObject {
+    [name: string]: OpenAPIExampleObject | REF_OBJECT;
+  }
+
+export interface OpenAPIExampleObject {
+    summary?: string;
+    description?: string;
+    value?: any;
+    externalValue?: string;
+    [property: string]: any;
+}
+
+export interface OpenAPIEncodingPropertyObject {
+    contentType?: string;
+    headers?: { [key: string]: OpenAPIHeaderObject | REF_OBJECT };
+    style?: string;
+    explode?: boolean;
+    allowReserved?: boolean;
+    [key: string]: any;
+}
+
+export interface OpenAPIEncodingObject extends WithAny {
+    // [property: string]: EncodingPropertyObject;
+    [property: string]: OpenAPIEncodingPropertyObject | any;
+}
+
+export interface OpenAPIMediaTypeObject extends WithAny {
+    schema?: OpenAPISchemaObject | REF_OBJECT;
+    examples?: OpenAPIExamplesObject;
+    example?: any;
+    encoding?: OpenAPIEncodingObject;
+}
+
+export interface OpenAPIContentObject {
+    [mediatype: string]: OpenAPIMediaTypeObject;
+}
+
+export interface OpenAPIBaseParameterObject extends WithAny {
+    description?: string;
+    required?: boolean;
+    deprecated?: boolean;
+    allowEmptyValue?: boolean;
+  
+    style?: OpenAPIParameterStyle;
+    explode?: boolean;
+    allowReserved?: boolean;
+    schema?: OpenAPISchemaObject | REF_OBJECT;
+    examples?: { [param: string]: OpenAPIExampleObject | REF_OBJECT };
+    example?: any;
+    content?: OpenAPIContentObject;
+}
+
+export interface OpenAPIHeaderObject extends OpenAPIBaseParameterObject {}
+
+export interface OpenAPIContact {
+    name: string;
+    url: string;
+    email: string;
+}
+export interface OpenAPILicense {
+    name: string;
+    url?: string;
+}
+export interface OpenAPIInfo {
+    title: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: OpenAPIContact;
+    license?: OpenAPILicense;
+    version: string;
+}
+export interface OpenAPIServerVariables {
+    enum?: string;
+    default: string;
+    description?: string;
+}
+export interface OpenAPIServer {
+    url: string;
+    description?: string;
+    variables?: {
+        [prop: string]: OpenAPIServerVariables
+    }
+}
+export interface OpenAPIExternalDocs {
+    description?: string;
+    url: string;
+}
+export interface OpenAPIParameter {
+    in?: "query" | "header" | "path" | "cookie";
+    description?: string;
+    required?: boolean;
+    deprecated?: boolean;
+    allowEmptyValue?: boolean;
+    schema?: OpenAPISchemaObject
+}
+export interface OpenAPISchemaObject extends WithAny {
+    nullable?: boolean;
+    discriminator?: OpenAPIDiscriminatorObject;
+    readOnly?: boolean;
+    writeOnly?: boolean;
+    xml?: OpenAPIXmlObject;
+    externalDocs?: OpenAPIExternalDocumentationObject;
+    example?: any;
+    examples?: any[];
+    deprecated?: boolean;
+  
+    type?: string;
+    allOf?: (OpenAPISchemaObject | REF_OBJECT)[];
+    oneOf?: (OpenAPISchemaObject | REF_OBJECT)[];
+    anyOf?: (OpenAPISchemaObject | REF_OBJECT)[];
+    not?: OpenAPISchemaObject | REF_OBJECT;
+    items?: OpenAPISchemaObject | REF_OBJECT;
+    properties?: { [propertyName: string]: OpenAPISchemaObject | REF_OBJECT };
+    additionalProperties?: OpenAPISchemaObject | REF_OBJECT | boolean;
+    description?: string;
+    format?: string;
+    default?: any;
+  
+    title?: string;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: boolean;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    required?: string[];
+    enum?: any[];
+}
+export interface OpenAPILinkObject extends WithAny {
+    operationRef?: string;
+    operationId?: string;
+    parameters?: { [name: string]: any | string };
+    requestBody?: any | string;
+    description?: string;
+    server?: OpenAPIServer;
+    [property: string]: any;
+}  
+export interface OpenAPIRequestBody {
+    description?: string;
+    content: {
+        [prop: string]: OpenAPISchemaObject
+    }
+    required?: boolean;
+}
+export interface OpenAPIContent {
+    [mediatype: string]: OpenAPIMediaTypeObject;
+  }
+export interface OpenAPIResponse {
+    description: string;
+    responseCode?: number;
+    headers?: {
+        [prop: string]: OpenAPIHeaderObject | REF_OBJECT
+    },
+    content?: {
+        [prop: string]: OpenAPIContent
+    },
+    links?: {
+        [prop: string]: OpenAPILinkObject | REF_OBJECT
+    }
+}
+export type OpenAPIResponseGeneral = {
+    [prop in string | number]: OpenAPIResponse | REF_OBJECT;
+} & {
+    default: OpenAPIResponse | REF_OBJECT;
+};
+export interface OpenAPIOperationObject {
+    tags?: Array<string>;
+    hidden?: boolean;
+    summary?: string;
+    description?: string;
+    externalDocs?: OpenAPIExternalDocs;
+    operationId?: string;
+    parameters?: Array<OpenAPIParameter | REF_OBJECT>;
+    requestBody?: OpenAPIRequestBody | REF_OBJECT;
+    responses: OpenAPIResponseGeneral;
+    callbacks?: {
+        [prop: string]: OpenAPIPath | REF_OBJECT | any;
+    },
+    deprecated?: boolean;
+    security?: {
+        [name: string]: string[];
+    },
+    servers?: Array<OpenAPIServer>
+}
+
+export interface OpenAPIPath {
+    $ref?: string;
+    summary?: string;
+    description?: string;
+    get?: OpenAPIOperationObject;
+    put?: OpenAPIOperationObject;
+    delete?: OpenAPIOperationObject;
+    options?: OpenAPIOperationObject;
+    head?: OpenAPIOperationObject;
+    patch?: OpenAPIOperationObject;
+    trace?: OpenAPIOperationObject;
+    servers?: Array<OpenAPIServer>;
+    parameters?: Array<OpenAPIParameter>;
+}
+
+export interface OpenAPIOAuthFlowObject extends WithAny {
+    authorizationUrl?: string;
+    tokenUrl?: string;
+    refreshUrl?: string;
+    scopes: {
+        [scope: string]: any
+    };
+}
+  
+export interface OpenAPIOAuthFlowsObject extends WithAny {
+    implicit?: OpenAPIOAuthFlowObject;
+    password?: OpenAPIOAuthFlowObject;
+    clientCredentials?: OpenAPIOAuthFlowObject;
+    authorizationCode?: OpenAPIOAuthFlowObject;
+}
+
+export interface OpenAPISecuritySchemeObject extends WithAny {
+    type: OpenAPISecuritySchemeType;
+    description?: string;
+    name?: string; 
+    in?: string; 
+    scheme?: string; 
+    bearerFormat?: string;
+    flows?: OpenAPIOAuthFlowsObject; 
+    openIdConnectUrl?: string;
+  }
+
+export interface OpenAPIComponentObject {
+    schemas?: {
+        [prop: string]: OpenAPISchemaObject | REF_OBJECT
+    },
+    responses?: {
+        [prop: string]: OpenAPIResponse | REF_OBJECT
+    },
+    parameters?: {
+        [prop: string]: OpenAPIParameter | REF_OBJECT
+    },
+    examples?: {
+        [prop: string]: OpenAPIExampleObject | REF_OBJECT
+    },
+    requestBodies?: {
+        [prop: string]: OpenAPIRequestBody | REF_OBJECT
+    },
+    headers?: {
+        [prop: string]: OpenAPIHeaderObject | REF_OBJECT
+    },
+    securitySchemes?: {
+        [prop: string]: OpenAPISecuritySchemeObject | REF_OBJECT
+    },
+    links?: {
+        [prop: string]: OpenAPILinkObject | REF_OBJECT
+    },
+    callbacks?: {
+        [prop: string]: OpenAPIPath | REF_OBJECT | any;
+    }
+}
+
+export interface OpenAPITagObject {
+    name: string;
+    description?: string;
+    externalDocs?: OpenAPIExternalDocumentationObject;
+}
+
+export interface OpenAPISpec {
+    openapi: string;
+    info: OpenAPIInfo;
+    servers?: Array<OpenAPIServer>;
+    paths: {
+        [path: string]: OpenAPIPath | REF_OBJECT
+    },
+    components?: OpenAPIComponentObject,
+    security?: {
+        [prop: string]: Array<string>
+    },
+    tags?: Array<OpenAPITagObject>;
+    externalDocs?: OpenAPIExternalDocumentationObject
+}

--- a/tests/integration-tests/files/openAPI.ts
+++ b/tests/integration-tests/files/openAPI.ts
@@ -1,0 +1,49 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { MandarineCore } from "../../../main-core/mandarineCore.ts";
+import { Controller } from "../../../mvc-framework/core/decorators/stereotypes/controller/controller.ts";
+import { GET } from "../../../mvc-framework/core/decorators/stereotypes/controller/routingDecorator.ts";
+import { ApiResponse } from "../../../mvc-framework/openapi/decorators/apiResponse.ts";
+import { ApiOperation } from "../../../mvc-framework/openapi/decorators/operation.ts";
+import { ApiParameter } from "../../../mvc-framework/openapi/decorators/parameter.ts";
+import { RouteParam } from "../../../mvc-framework/core/decorators/stereotypes/controller/parameterDecorator.ts";
+import { ApiTag } from "../../../mvc-framework/openapi/decorators/apiTag.ts";
+
+@Controller() 
+@ApiResponse({ responseCode: "NotFound", description: "The requested information was not found" })
+export class MyController { 
+
+    @GET('/:username')
+    @ApiOperation({
+        summary: "Get user by user name",
+        responses: {
+            default: {
+                description: "The user",
+                content: {
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/User"
+                        }
+                    }
+                }
+            },
+            400: {
+                responseCode: 400,
+                description: "User not found"
+            }
+        }
+    })
+    @ApiTag("Hello")
+    @ApiTag(["Hello2", "Hello3"])
+    @ApiTag({name: "Deno"})
+    @ApiTag({name: "NodeJS", description:"Runtime"})
+    @ApiTag(["JAJA", {name: "Framework", description:".NET"}])
+    @ApiResponse({ description: "lol" })
+    public httpHandler(@ApiParameter({ description: "The name that needs to be fetched. Use user1 for testing.", required: true }) @RouteParam() username: string) { 
+        return "Welcome to MandarineTS Framework!"; 
+    } 
+
+} 
+
+new MandarineCore().MVC().saveOpenAPI('./openapi.yml').run();
+Deno.exit();

--- a/tests/integration-tests/openapi_test.ts
+++ b/tests/integration-tests/openapi_test.ts
@@ -1,0 +1,32 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
+import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+
+export class OpenAPITest {
+
+    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
+
+    constructor() {
+    }
+
+    @Test({
+        name: "[IT04] Test OpenAPI from `files/openAPI.ts`",
+        description: "Verifies Mandarine generates the right file structure for OpenAPI metadata"
+    })
+    public async testOpenAPIFileGenerated() {
+        let cmd = Deno.run({
+            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/openAPI.ts`],
+            stdout: "null",
+            stderr: "null",
+            stdin: "null"
+        });
+        await cmd.status();
+
+        const fileContent = Deno.readTextFileSync('./openapi.yml');
+        const fileContentExpected = Deno.readTextFileSync('./tests/integration-tests/resources/openapi.yml');
+        DenoAsserts.assertEquals(fileContent, fileContentExpected);
+        cmd.close();
+    }
+
+}

--- a/tests/integration-tests/openapi_test.ts
+++ b/tests/integration-tests/openapi_test.ts
@@ -12,7 +12,8 @@ export class OpenAPITest {
 
     @Test({
         name: "[IT04] Test OpenAPI from `files/openAPI.ts`",
-        description: "Verifies Mandarine generates the right file structure for OpenAPI metadata"
+        description: "Verifies Mandarine generates the right file structure for OpenAPI metadata",
+        ignore: Deno.build.os == "windows"
     })
     public async testOpenAPIFileGenerated() {
         let cmd = Deno.run({

--- a/tests/integration-tests/openapi_test.ts
+++ b/tests/integration-tests/openapi_test.ts
@@ -25,7 +25,7 @@ export class OpenAPITest {
 
         const fileContent = Deno.readTextFileSync('./openapi.yml');
         const fileContentExpected = Deno.readTextFileSync('./tests/integration-tests/resources/openapi.yml');
-        DenoAsserts.assertEquals(fileContent, fileContentExpected);
+        DenoAsserts.assertStringIncludes(fileContent, fileContentExpected);
         cmd.close();
     }
 

--- a/tests/integration-tests/resources/openapi.yml
+++ b/tests/integration-tests/resources/openapi.yml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: App
+  version: 1.0.0
+servers: []
+paths:
+  '/:username':
+    get:
+      summary: Get user by user name
+      responses:
+        '400':
+          responseCode: 400
+          description: User not found
+        default:
+          description: lol
+      operationId: httpHandler
+      parameters:
+        - description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          in: path
+          schema:
+            type: string
+          name: username
+      tags:
+        - JAJA
+        - Framework
+        - NodeJS
+        - Deno
+        - Hello2
+        - Hello3
+        - Hello
+components:
+  schemas: {}
+  responses: {}
+  parameters: {}
+  examples: {}
+  requestBodies: {}
+  headers: {}
+  securitySchemes: {}
+  links: {}
+  callbacks: {}
+tags:
+  - name: Framework
+    description: .NET
+  - name: NodeJS
+    description: Runtime


### PR DESCRIPTION
Support open api:
`@ApiOperation` decorator
`@ApiParameter` decorator
`@ApiResponse` decorator
`@ApiServer` decorator
`@ApiTag` decorator

.

Generation of OpenAPI specs (in json and yaml).

This is a first version and still needs enhancements. 
close #250 

