### PR TITLE
minor CORS bugfixes

### DIFF
--- a/mvc-framework/core/middlewares/cors/corsMiddleware.ts
+++ b/mvc-framework/core/middlewares/cors/corsMiddleware.ts
@@ -52,8 +52,8 @@ export const handleCors = (requestContext: Mandarine.Types.RequestContext, data:
 
         const requestHeaders = req.headers.get("access-control-request-headers");
         if (requestHeaders && corsOptions.allowedHeaders && corsOptions.allowedHeaders.length > 0) {
-            const list = requestHeaders.split(",").map((v) => v.trim());
-            const allowed = list.filter((v) => corsOptions.allowedHeaders?.includes(v));
+            const list = requestHeaders.split(",").map((v) => v.trim().toLowerCase());
+            const allowed = list.filter((v) => corsOptions.allowedHeaders?.map((v) => v.toLowerCase()).includes(v));
             res.headers.set("access-control-allow-headers",allowed.join(", "));
         }
 

--- a/mvc-framework/core/middlewares/cors/corsMiddleware.ts
+++ b/mvc-framework/core/middlewares/cors/corsMiddleware.ts
@@ -15,7 +15,7 @@ const configureOrigin = (corsOptions: Mandarine.MandarineMVC.CorsMiddlewareOptio
 
 const configureExposeHeaders = (corsOptions: Mandarine.MandarineMVC.CorsMiddlewareOption, res: Mandarine.MandarineMVC.ResponseContext) => {
     if (corsOptions.exposedHeaders && corsOptions.exposedHeaders.length > 0) {
-        res.headers.set("accessl-control-expose-headers", corsOptions.exposedHeaders.join(", "));
+        res.headers.set("access-control-expose-headers", corsOptions.exposedHeaders.join(", "));
     }
 }
 

--- a/tests/unit-tests/cors_test.ts
+++ b/tests/unit-tests/cors_test.ts
@@ -108,7 +108,7 @@ export class CORSTest {
         DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-allow-origin"), false);
         DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-allow-methods"), "POST, GET");
         DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-allow-headers"), "allowed-header-1");
-        DenoAsserts.assertEquals(requestMock.response.headers.get("accessl-control-expose-headers"), "exposed-header-1, exposed-header-2");
+        DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-expose-headers"), "exposed-header-1, exposed-header-2");
         DenoAsserts.assert(requestMock.response.headers.get("access-control-allow-credentials") == undefined);
         DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-max-age"), "100");
 
@@ -121,7 +121,7 @@ export class CORSTest {
             useDefaultCors: false
         });
         DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-allow-origin"), false);
-        DenoAsserts.assertEquals(requestMock.response.headers.get("accessl-control-expose-headers"), "exposed-header-1, exposed-header-2");
+        DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-expose-headers"), "exposed-header-1, exposed-header-2");
         DenoAsserts.assert(requestMock.response.headers.get("access-control-allow-credentials") == undefined);
 
         //RESET
@@ -135,7 +135,7 @@ export class CORSTest {
             useDefaultCors: false
         });
         DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-allow-origin"), "http://localhost");
-        DenoAsserts.assertEquals(requestMock.response.headers.get("accessl-control-expose-headers"), "exposed-header-1, exposed-header-2");
+        DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-expose-headers"), "exposed-header-1, exposed-header-2");
         DenoAsserts.assertEquals(requestMock.response.headers.get("access-control-allow-credentials"), "true");
 
         //RESET


### PR DESCRIPTION
* fix typo `accessl-control-expose-headers` => `access-control-expose-headers`
* ensure `access-control-request-headers` as well as `@Cors(allowedHeaders)` values are case insensitive