### PR TITLE
speed up integration tests

### DIFF
--- a/tests/integration-tests/customCatch_test.ts
+++ b/tests/integration-tests/customCatch_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class CustomCatchTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class CustomCatchTest {
         description: "Test all endpoints in file, and verifies that a custom exception catcher is working."
     })
     public async testCustomCatch() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/customCatch.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("customCatch.ts");
 
         let internalServerError = (await (await fetch("http://localhost:2490/throw")).text());
         let customException = (await (await fetch("http://localhost:2490/throw-2")).json());

--- a/tests/integration-tests/customDecorator_test.ts
+++ b/tests/integration-tests/customDecorator_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class CustomDecoratorIntTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class CustomDecoratorIntTest {
         description: "Test all endpoints in file, and verifies that a simple custom decorator is working fine."
     })
     public async testCustomDecorator() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/customDecorator.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("customDecorator.ts");
 
         let customDecoratorMsg = (await (await fetch("http://localhost:2193/hello-world")).text());
 

--- a/tests/integration-tests/guards_test.ts
+++ b/tests/integration-tests/guards_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class GuardsTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 55;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class GuardsTest {
         description: "Test all endpoints in file, and verifies that guards are working fine"
     })
     public async testGuardsEndpoints() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/guards.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("guards.ts");
 
         let test1 = (await (await fetch("http://localhost:7555/hello-world")).text());
         let test2 = (await (await fetch("http://localhost:7555/protected")).text());

--- a/tests/integration-tests/manualInjection_test.ts
+++ b/tests/integration-tests/manualInjection_test.ts
@@ -1,11 +1,10 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class ManualInjectionTest {
 
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +19,7 @@ export class ManualInjectionTest {
         description: "Test all endpoints in file, and verifies its return values"
     })
     public async testManualInjectionEndpoint() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/manualInjection.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("manualInjection.ts");
 
         let testingManualInjection = (await (await fetch("http://localhost:8082/testing-manual-injection")).text());
 

--- a/tests/integration-tests/middleware_test.ts
+++ b/tests/integration-tests/middleware_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class MiddlewareTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class MiddlewareTest {
         description: "Test all endpoints in file, and verifies middleware references are working fine"
     })
     public async testMiddlewareEndpoints() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/middleware.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("middleware.ts");
 
         let test1 = (await (await fetch("http://localhost:2024/with-middleware-controller")).json());
         let test2 = (await (await fetch("http://localhost:2024/with-middleware-method")).json());

--- a/tests/integration-tests/nestedInjection_test.ts
+++ b/tests/integration-tests/nestedInjection_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class NestedInjectionTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class NestedInjectionTest {
         description: "Test all endpoints in file, and verifies its return values"
     })
     public async testPiInService() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/nestedInjections.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("nestedInjections.ts");
 
         let testingManualInjection = (await (await fetch("http://localhost:8083/test")).text());
 

--- a/tests/integration-tests/pipe_test.ts
+++ b/tests/integration-tests/pipe_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts,  Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class PipeTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 55;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class PipeTest {
         description: "Test all endpoints in file, and verifies that transformation from pipe is working fine"
     })
     public async testManualInjectionEndpoint() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/pipes.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("pipes.ts");
 
         let test1 = (await (await fetch("http://localhost:5320/hello-world?id=4")).json());
 

--- a/tests/integration-tests/resourceHandlerStaticContent_test.ts
+++ b/tests/integration-tests/resourceHandlerStaticContent_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class ResourceHandlerStaticContentTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class ResourceHandlerStaticContentTest {
         description: "Verifies Mandarine is serving static content"
     })
     public async testTemplatesEndpoints() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/resourceHandlerStaticContent.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("resourceHandlerStaticContent.ts");
 
         let resourceRequest = (await (await fetch("http://localhost:8091/docs/testing/helloWorld.txt")).text());
 

--- a/tests/integration-tests/routeParam_test.ts
+++ b/tests/integration-tests/routeParam_test.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class RouteParamTest {
-
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 50;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +18,7 @@ export class RouteParamTest {
         description: "Test all endpoints in file, and verifies its return values"
     })
     public async testSayHi() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/routeParam.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("routeParam.ts");
 
         let sayHiNameEndpoint = (await (await fetch("http://localhost:8081/say-hi-1/Andres")).json());
         let apiSayHiNameEndpoint = (await (await fetch("http://localhost:8081/api/say-hi-2/Bill")).json());

--- a/tests/integration-tests/sessionCounter_test.ts
+++ b/tests/integration-tests/sessionCounter_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class SessionCounterTest {
 
@@ -20,14 +20,7 @@ export class SessionCounterTest {
         description: "Verifies Mandarine native session system is working properly"
     })
     public async testSessionCounter() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/sessionCounter.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("sessionCounter.ts");
 
         let sessionCounter = (await (await fetch("http://localhost:8084/session-counter")).json());
         let sessionIdCookie = sessionCounter.sessionId;

--- a/tests/integration-tests/templatest_test.ts
+++ b/tests/integration-tests/templatest_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class TemplatesTest {
 
@@ -20,14 +20,7 @@ export class TemplatesTest {
         description: "Verifies manual templates are working properly"
     })
     public async testTemplatesEndpoints() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/templates.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("templates.ts");
 
         let ejsTemplate = (await (await fetch("http://localhost:8090/manual-template-ejs")).text());
         let handlebarsTemplate = (await (await fetch("http://localhost:8090/manual-template-handlebars")).text());

--- a/tests/integration-tests/valueConfigurationProperties_test.ts
+++ b/tests/integration-tests/valueConfigurationProperties_test.ts
@@ -1,11 +1,10 @@
 // Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
 import { CommonUtils } from "../../main-core/utils/commonUtils.ts";
-import { DenoAsserts, INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY, Orange, Test } from "../mod.ts";
+import { DenoAsserts, Orange, Test, waitForMandarineServer } from "../mod.ts";
 
 export class ValueConfigurationProperties {
 
-    public MAX_COMPILATION_TIMEOUT_SECONDS = 55;
 
     constructor() {
         Orange.setOptions(this, {
@@ -20,14 +19,7 @@ export class ValueConfigurationProperties {
         description: "Test all endpoints in file, and verifies that custom properties and value decorator are working fine"
     })
     public async testValueAndConfigurationProperties() {
-        let cmd = Deno.run({
-            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/customPropertiesAndValue.ts`],
-            stdout: "null",
-            stderr: "null",
-            stdin: "null"
-        });
-
-        CommonUtils.sleep(this.MAX_COMPILATION_TIMEOUT_SECONDS);
+        let cmd = await waitForMandarineServer("customPropertiesAndValue.ts");
 
         let test1 = (await (await fetch("http://localhost:7751/my-custom-config")).text());
 

--- a/tests/mod.ts
+++ b/tests/mod.ts
@@ -46,7 +46,7 @@ export function createResolvable<T>(): Resolvable<T> {
 
 export const INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY = "./tests/integration-tests/files";
 
-export function waitForMandarineServer(integrationTestFixtureFilename: string): Promise<Deno.Process> {
+export function waitForMandarineServer(integrationTestFixtureFilename: string): Promise<{proc: Deno.Process, close: () => void}> {
 
     return new Promise((resolve, reject) => {
         const proc = Deno.run({
@@ -69,8 +69,8 @@ export function waitForMandarineServer(integrationTestFixtureFilename: string): 
                 } else {
                     stdoutText += textDecoder.decode(lastOutput);
                     if (stdoutText.indexOf("[MandarineMVC.class] Server has started") !== -1) {
-                        proc.stdout!.close();
-                        resolve(proc);
+                        resolve({proc, close: () => { proc.stdout!.close(); proc.close(); }});
+
                     } else {
                         setTimeout(readOutput, 250);
                     }

--- a/tests/mod.ts
+++ b/tests/mod.ts
@@ -45,3 +45,39 @@ export function createResolvable<T>(): Resolvable<T> {
 }
 
 export const INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY = "./tests/integration-tests/files";
+
+export function waitForMandarineServer(integrationTestFixtureFilename: string): Promise<Deno.Process> {
+
+    return new Promise((resolve, reject) => {
+        const proc = Deno.run({
+            cmd: ["deno", "run", "-c", "tsconfig.json", "--allow-all", "--unstable", `${INTEGRATION_TEST_FILES_TO_RUN_DIRECTORY}/${integrationTestFixtureFilename}`],
+            stdout: "piped",
+            stderr: "null",
+            stdin: "null"
+        });
+
+        const lastOutput = new Uint8Array(1024)
+        const textDecoder = new TextDecoder();
+        let stdoutText = "";
+
+
+        const readOutput = () => {
+            proc.stdout!.read(lastOutput).then((bytesRead) => {
+                if (bytesRead === null) {
+                    proc.stdout!.close();
+                    reject("Process ended without having successfully started Mandarine server. Here its stdout: \n\n" + stdoutText);
+                } else {
+                    stdoutText += textDecoder.decode(lastOutput);
+                    if (stdoutText.indexOf("[MandarineMVC.class] Server has started") !== -1) {
+                        proc.stdout!.close();
+                        resolve(proc);
+                    } else {
+                        setTimeout(readOutput, 250);
+                    }
+                }
+            });
+        };
+        readOutput();
+    });
+}
+


### PR DESCRIPTION
Many integration tests just need to wait for the Mandarine server to start up. 

Currently, they do that with a rather generous hardcoded timeout.

This PR adds a `waitForMandarineServer` function that takes an integration test app file name and returns a promise that resolves as soon as the Mandarine server is initialized and listening. Feels a bit hacky but seems to work.

Anyway, this can considerably speed up execution time for the integration tests.

A lot of possible improvements come to mind (expose pipes / pass piping options? re-introduce max timeout & kill process when it hangs?) but this may serve as a start.
