### PR TITLE
fix typo in 'access-control-request-method'

### DIFF
--- a/mvc-framework/core/middlewares/cors/corsMiddleware.ts
+++ b/mvc-framework/core/middlewares/cors/corsMiddleware.ts
@@ -42,7 +42,7 @@ export const handleCors = (requestContext: Mandarine.Types.RequestContext, data:
 
         configureOrigin(corsOptions, res, requestOrigin);
 
-        const requestMethods = req.headers.get("access-control-request-methods");
+        const requestMethods = req.headers.get("access-control-request-method");
         if (requestMethods && corsOptions.methods && corsOptions.methods.length > 0) {
             const list = requestMethods.split(",").map((v) => v.trim());
             const allowed = list.filter((v) => corsOptions.methods?.includes(v));

--- a/tests/unit-tests/cors_test.ts
+++ b/tests/unit-tests/cors_test.ts
@@ -97,7 +97,7 @@ export class CORSTest {
 
         let requestMock = this.getMockObject("OPTIONS");
 
-        requestMock.request.headers.set("access-control-request-methods", "POST, DELETE, GET");
+        requestMock.request.headers.set("access-control-request-method", "POST, DELETE, GET");
         requestMock.request.headers.set("access-control-request-headers", "Origin, allowed-header-1, Content-Type");
 
         requestMock.request.headers.set("origin", "http://localhost");


### PR DESCRIPTION
the *request* header name is written in the singular ([`access-control-request-method`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method) instead of access-control-request-methods)
– in contrast to the *response* header, which is [`access-control-allow-methods`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)