### PR TITLE
Allow multiple configuration types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,8 @@ jobs:
       - name: Cache manager
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-        run: deno test -c tsconfig.json --reload --allow-all --unstable --fail-fast tests/unit-tests/cacheManager.ts             
+        run: deno test -c tsconfig.json --reload --allow-all --unstable --fail-fast tests/unit-tests/cacheManager.ts 
+      - name: Configuration setter
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        run: deno test -c tsconfig.json --reload --allow-all --unstable --fail-fast tests/unit-tests/setConfiguration.ts                         

--- a/main-core/Mandarine.ns.ts
+++ b/main-core/Mandarine.ns.ts
@@ -32,6 +32,8 @@ import { Microlemon }  from "./microservices/mod.ts";
 import { MicroserviceManager } from "./microservices/microserviceManager.ts";
 import { MandarineCoreTimers } from "./internals/core/mandarineCoreTimers.ts";
 import { MandarineConstants } from "./mandarineConstants.ts";
+import { YamlUtils } from "./utils/yamlUtils.ts";
+import { PropertiesUtils } from "./utils/propertiesUtils.ts";
 
 /**
 * This namespace contains all the essentials for mandarine to work
@@ -303,17 +305,31 @@ export namespace Mandarine {
         */
         export function getMandarineConfiguration(configPath?: string): Properties {
             let mandarineGlobal: MandarineGlobalInterface = getMandarineGlobal();
-
-            if(mandarineGlobal.mandarineProperties == (null || undefined)) {
-
+            if(!mandarineGlobal.mandarineProperties) {
                 try {
                     const initialProperties: MandarineInitialProperties | undefined = getMandarineInitialProps();
                     let mandarinePropertiesFile = configPath || Deno.env.get(MandarineEnvironmentalConstants.MANDARINE_PROPERTY_FILE) || initialProperties?.propertiesFilePath || Defaults.mandarinePropertiesFile;
-                    const propertiesData = JsonUtils.toJson(mandarinePropertiesFile, { isFile: true, allowEnvironmentalReferences: true });
+                    let fileExtOpts = mandarinePropertiesFile.split(".");
+                    let fileExt = fileExtOpts[fileExtOpts.length - 1].toLowerCase();
+
+                    let propertiesData: any;
+                    logger.debug(`Using configuration with type: ${fileExt}`);
+                    if(fileExt === "json") {
+                        propertiesData = JsonUtils.toJson(mandarinePropertiesFile, { isFile: true, allowEnvironmentalReferences: true });
+                    } else if(fileExt === "yaml" || fileExt === "yml") {
+                        const yamlContent = JSON.stringify(YamlUtils.yamlFileToJS(mandarinePropertiesFile));
+                        propertiesData = JsonUtils.toJson(yamlContent, { isFile: false, allowEnvironmentalReferences: true });
+                    } else if(fileExt === "properties") {
+                        const propertiesContent = JSON.stringify(PropertiesUtils.propertiesToJS(mandarinePropertiesFile));
+                        propertiesData = JsonUtils.toJson(propertiesContent, { isFile: false, allowEnvironmentalReferences: true });
+                    }
+
                     setConfiguration(propertiesData);
                 } catch(error) {
                     mandarineGlobal.mandarineProperties = Defaults.MandarineDefaultConfiguration;
                     logger.warn(`properties.json could not be found or parsed. Using default values. `);
+                    logger.debug(`Properties file: ${configPath}`);
+                    logger.debug(`Properties reading error ${error.message}`)
                 }
 
             }

--- a/main-core/utils/propertiesUtils.ts
+++ b/main-core/utils/propertiesUtils.ts
@@ -1,0 +1,47 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { CommonUtils } from "./commonUtils.ts";
+import { MandarineUtils } from "./mandarineUtils.ts";
+
+export class PropertiesUtils {
+
+    private static parseLine(obj: any, keys: string | Array<string>, value: any)
+    {
+        keys = (typeof keys === "string") ? keys.split(".") : keys;
+        const key = keys.shift()!;
+    
+        if (keys.length === 0)
+        {
+            obj[key] = value;
+            return;
+        }
+        else if (!obj.hasOwnProperty(key))
+        {
+            obj[key] = {};
+        }
+    
+        this.parseLine(obj[key], keys, CommonUtils.parseToKnownType(value));
+        return obj;
+    }
+
+    public static parse(input: string) {
+        const dividedInput = MandarineUtils.parseConfigurationFile(input);
+        const object = {};
+
+        Object.keys(dividedInput).forEach((key) => {
+            this.parseLine(object, key, dividedInput[key]);
+        });
+
+        return object;
+    }
+
+    public static propertiesToJS(path: string) {
+        try {
+            const content = Deno.readTextFileSync(path);
+            return this.parse(content);
+        } catch {
+            return {};
+        }
+    }
+
+}

--- a/main-core/utils/yamlUtils.ts
+++ b/main-core/utils/yamlUtils.ts
@@ -1,0 +1,25 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import  * as YAML from "https://deno.land/std@0.85.0/encoding/yaml.ts";
+
+
+export class YamlUtils {
+
+    public static yamlFileToJS(path: string) {
+        try {
+            const content = Deno.readTextFileSync(path);
+            return this.yamlToJS(content);
+        } catch {
+            return {};
+        }
+    }
+
+    public static yamlToJS(yaml: string): any {
+        return YAML.parse(yaml);
+    }
+
+    public static jsToYaml(js: any) {
+        return YAML.stringify(js);
+    }
+    
+}

--- a/tests/unit-tests/files/jsonConf.json
+++ b/tests/unit-tests/files/jsonConf.json
@@ -1,0 +1,16 @@
+{
+    "mandarine": { 
+      "server": {
+        "host": "127.0.0.1",
+        "port": 8080
+      },
+      "enabled": true,
+      "auth": {
+        "data": {
+          "config": {
+            "username": "andreespirela"
+          }
+        }
+      }
+    }
+}

--- a/tests/unit-tests/files/props.properties
+++ b/tests/unit-tests/files/props.properties
@@ -1,0 +1,4 @@
+mandarine.server.host=127.0.0.1
+mandarine.server.port=8080
+mandarine.enabled=true
+mandarine.auth.data.config.username=andreespirela

--- a/tests/unit-tests/files/yamlConf.yaml
+++ b/tests/unit-tests/files/yamlConf.yaml
@@ -1,0 +1,10 @@
+---
+mandarine:
+  server:
+    host: 127.0.0.1
+    port: 8080
+  enabled: true
+  auth:
+    data:
+      config:
+        username: andreespirela

--- a/tests/unit-tests/setConfiguration.ts
+++ b/tests/unit-tests/setConfiguration.ts
@@ -1,0 +1,52 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { Mandarine } from "../../main-core/Mandarine.ns.ts";
+import { ApplicationContext } from "../../mod.ts";
+import { DenoAsserts, Orange, Test } from "./../mod.ts";
+
+export class CacheManager {
+
+    constructor() {
+        Orange.setOptions(this, {
+            hooks: {
+                beforeAll: () => {
+                    //@ts-ignore
+                    Mandarine.Global.getMandarineGlobal().mandarineProperties = undefined;
+                },
+                beforeEach: () => {
+                    //@ts-ignore
+                    Mandarine.Global.getMandarineGlobal().mandarineProperties = undefined;
+                },
+                afterEach: () => {
+                    DenoAsserts.assertEquals(Mandarine.Global.readConfigByDots("mandarine.server.host"), "127.0.0.1");
+                    DenoAsserts.assertEquals(Mandarine.Global.readConfigByDots("mandarine.server.port"), 8080);
+                    DenoAsserts.assertEquals(Mandarine.Global.readConfigByDots("mandarine.enabled"), true);
+                    DenoAsserts.assertEquals(Mandarine.Global.readConfigByDots("mandarine.auth.data.config.username"), "andreespirela");
+                }
+            }
+        })
+    }
+
+    @Test({
+        name: "Test setConfiguration with JSON file"
+    })
+    public testSetConfigurationJSON() {
+        Mandarine.Global.getMandarineConfiguration('./tests/unit-tests/files/jsonConf.json');
+    }
+
+
+    @Test({
+        name: "Test setConfiguration with YAML file"
+    })
+    public testSetConfigurationYAML() {
+        Mandarine.Global.getMandarineConfiguration('./tests/unit-tests/files/yamlConf.yaml');
+    }
+
+    @Test({
+        name: "Test setConfiguration with properties file"
+    })
+    public testSetConfigurationProps() {
+        Mandarine.Global.getMandarineConfiguration('./tests/unit-tests/files/props.properties');
+    }
+
+}

--- a/tests/unit-tests/utils/propertiesUtils_test.ts
+++ b/tests/unit-tests/utils/propertiesUtils_test.ts
@@ -1,0 +1,33 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { Test, DenoAsserts, Orange } from "../../mod.ts";
+import { PropertiesUtils } from "../../../main-core/utils/propertiesUtils.ts";
+
+export class PropertiesUtilsTest {
+
+    @Test({
+        name: "Test parsing properties file",
+        description: "Should parse properties to a JS object"
+    })
+    public testPropertiesParsing() {
+        const properties = ["mandarine.server.host=127.0.0.1", "mandarine.server.port=8080", "mandarine.enabled=true", "mandarine.auth.data.config.user=andreespirela"];
+        const propertiesText = properties.join(`\n`);
+        const parsing = PropertiesUtils.parse(propertiesText);
+        DenoAsserts.assertEquals({
+            mandarine: {
+                server: {
+                    host: "127.0.0.1",
+                    port: 8080
+                },
+                enabled: true,
+                auth: {
+                    data: {
+                        config: {
+                            user: "andreespirela"
+                        }
+                    }
+                }
+            }
+        }, parsing);
+    }
+}

--- a/tests/unit-tests/utils/yamlUtils_test.ts
+++ b/tests/unit-tests/utils/yamlUtils_test.ts
@@ -1,0 +1,34 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { Test, DenoAsserts, Orange } from "../../mod.ts";
+import { YamlUtils } from "../../../main-core/utils/yamlUtils.ts";
+
+export class PropertiesUtilsTest {
+
+    @Test({
+        name: "Test parsing yaml file",
+        description: "Should parse yaml to a JS object"
+    })
+    public testPropertiesParsing() {
+        const expected = {
+            "mandarine": { 
+              "server": {
+                "host": "127.0.0.1",
+                "port": 8080
+              },
+              "enabled": true,
+              "auth": {
+                "data": {
+                  "config": {
+                    "username": "andreespirela"
+                  }
+                }
+              }
+            }
+          };
+        const yaml = YamlUtils.jsToYaml(expected);
+
+        const parsing = YamlUtils.yamlToJS(yaml);
+        DenoAsserts.assertEquals(parsing, expected);
+    }
+}


### PR DESCRIPTION
This PR allows the use of `.yaml`, `.yml`, and `.properties` in Mandarine configuration. 
This PR introduces testing for Mandarine configuration setter.