### PR TITLE
Update reflectMetadata.ts

### DIFF
--- a/main-core/reflectMetadata.ts
+++ b/main-core/reflectMetadata.ts
@@ -91,7 +91,6 @@ export namespace Reflect {
     }
 
     type MemberDecorator = <T>(target: Object, propertyKey: string | symbol, descriptor?: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void;
-    declare const Symbol: { iterator: symbol, toPrimitive: symbol };
     declare const Set: SetConstructor;
     declare const WeakMap: WeakMapConstructor;
     declare const Map: MapConstructor;


### PR DESCRIPTION
Deno 1.14 introduce TypeScript 4.4 which contain a change of `symbol`, 
[Deno 1.14 Release](https://deno.com/blog/v1.14)
[Announcing TypeScript 4.4](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/)
borrow idea from [deno-reflect-metadata](https://github.com/cmd-johnson/deno-reflect-metadata/commit/e56b8384c559e6f9543f44d7aa6e59c9a02ee695) that remove decaration of `Symbol`
